### PR TITLE
chore: add CODEOWNERS for auto request review

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+*       @toposware/protocol
+
+# Github Actions
+/.github/workflows/ @toposware/protocol @sebastiendan
+


### PR DESCRIPTION
Adding simple first [CODEOWNERS](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) for automatic review requests.
All the team is requested for now at least as ping to see whats happening here and there.