### PR TITLE
ci: specialize caching by ref slug

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -22,19 +22,29 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+
+      - name: Inject slug/short variables
+        uses: rlespinasse/github-slug-action@v4
+        with:
+          short-length: 7
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
       - uses: docker/build-push-action@v3
         with:
           target: fmt
           build-args: |
             GITHUB_TOKEN=${{ secrets.ROBOT_TOPOSWARE_GH_PACKAGE_TOKEN }}
             TOOLCHAIN_VERSION=${{ matrix.version }}
-          cache-from: type=registry,ref=ghcr.io/${{ github.repository }}:build-cache-${{ github.workflow }}-${{ matrix.version }}
-          cache-to: type=registry,ref=ghcr.io/${{ github.repository }}:build-cache-${{ github.workflow }}-${{ matrix.version }},mode=max
+          cache-from: |
+            type=registry,ref=ghcr.io/${{ github.repository }}:build-cache-${{ env.GITHUB_REF_SLUG_URL }}-${{ github.workflow }}-${{ matrix.version }}
+            type=registry,ref=ghcr.io/${{ github.repository }}:build-cache-main-${{ github.workflow }}-${{ matrix.version }}
+          cache-to: type=registry,ref=ghcr.io/${{ github.repository }}:build-cache-${{ env.GITHUB_REF_SLUG_URL }}-${{ github.workflow }}-${{ matrix.version }},mode=max

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,19 +22,29 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+
+      - name: Inject slug/short variables
+        uses: rlespinasse/github-slug-action@v4
+        with:
+          short-length: 7
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
       - uses: docker/build-push-action@v3
         with:
           target: lint
           build-args: |
             GITHUB_TOKEN=${{ secrets.ROBOT_TOPOSWARE_GH_PACKAGE_TOKEN }}
             TOOLCHAIN_VERSION=${{ matrix.version }}
-          cache-from: type=registry,ref=ghcr.io/${{ github.repository }}:build-cache-${{ github.workflow }}-${{ matrix.version }}
-          cache-to: type=registry,ref=ghcr.io/${{ github.repository }}:build-cache-${{ github.workflow }}-${{ matrix.version }},mode=max
+          cache-from: |
+            type=registry,ref=ghcr.io/${{ github.repository }}:build-cache-${{ env.GITHUB_REF_SLUG_URL }}-${{ github.workflow }}-${{ matrix.version }}
+            type=registry,ref=ghcr.io/${{ github.repository }}:build-cache-main-${{ github.workflow }}-${{ matrix.version }}
+          cache-to: type=registry,ref=ghcr.io/${{ github.repository }}:build-cache-${{ env.GITHUB_REF_SLUG_URL }}-${{ github.workflow }}-${{ matrix.version }},mode=max

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,19 +21,29 @@ jobs:
     runs-on: ${{ matrix.target.os }}
     steps:
       - uses: actions/checkout@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+
+      - name: Inject slug/short variables
+        uses: rlespinasse/github-slug-action@v4
+        with:
+          short-length: 7
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
       - uses: docker/build-push-action@v3
         with:
           target: test
           build-args: |
             GITHUB_TOKEN=${{ secrets.ROBOT_TOPOSWARE_GH_PACKAGE_TOKEN }}
             TOOLCHAIN_VERSION=${{ matrix.version }}
-          cache-from: type=registry,ref=ghcr.io/${{ github.repository }}:build-cache-${{ github.workflow }}-${{ matrix.version }}
-          cache-to: type=registry,ref=ghcr.io/${{ github.repository }}:build-cache-${{ github.workflow }}-${{ matrix.version }},mode=max
+          cache-from: |
+            type=registry,ref=ghcr.io/${{ github.repository }}:build-cache-${{ env.GITHUB_REF_SLUG_URL }}-${{ github.workflow }}-${{ matrix.version }}
+            type=registry,ref=ghcr.io/${{ github.repository }}:build-cache-main-${{ github.workflow }}-${{ matrix.version }}
+          cache-to: type=registry,ref=ghcr.io/${{ github.repository }}:build-cache-${{ env.GITHUB_REF_SLUG_URL }}-${{ github.workflow }}-${{ matrix.version }},mode=max


### PR DESCRIPTION
Improve workflow caching strategy by specializing cache layers by ref slug (instead of only workflow name and rust version).