### PR TITLE
fix: add init process to docker compose services

### DIFF
--- a/tools/docker-compose.yml
+++ b/tools/docker-compose.yml
@@ -11,6 +11,7 @@ services:
   boot:
     container_name: boot
     image: ghcr.io/toposware/tce:pr-4
+    init: true
     build:
       context: ../
       args:
@@ -38,6 +39,7 @@ services:
 
   peer:
     image: ghcr.io/toposware/tce:pr-4
+    init: true
     build:
       context: ../
       args:
@@ -70,6 +72,7 @@ services:
   cert-spammer:
     container_name: spam
     image: ghcr.io/toposware/cert-spammer:main
+    init: true
     environment:
       - RUST_LOG=debug
       - TARGET_NODES_PATH=/nodes.json


### PR DESCRIPTION
_TL;DR_: Run an init inside the container that forwards signals and reaps processes.

## Before
The current configuration allows us to run `$ docker compose up` in a very handy way to spawn all the necessary services. To stop and remove containers, we can `$ docker compose down` or simply `CTRL+C`.

However, it's possible to observe that the containers are reaching the [10s timeout and forcefully being killed](https://docs.docker.com/compose/faq/#why-do-my-services-take-10-seconds-to-recreate-or-stop):
```
$ docker compose down
[+] Running 11/11
 ⠿ Container spam          Removed     0.2s
 ⠿ Container grafana       Removed     0.2s
 ⠿ Container prometheus    Removed     0.2s
 ⠿ Container cadvisor      Removed     0.2s
 ⠿ Container tools-peer-1  Removed    10.5s
 ⠿ Container tools-peer-3  Removed    10.4s
 ⠿ Container tools-peer-2  Removed    10.4s
 ⠿ Container tools-peer-4  Removed    10.3s
 ⠿ Container tools-peer-5  Removed    10.2s
 ⠿ Container boot          Removed    10.2s
 ⠿ Network tools_default   Removed     0.1s
```

Each ~container~ service is synchronously removed, adding up to `~ (number of services * 10) seconds` to gracefully stop everything. In a larger scale environment, it may be an issue.

## After
This change adds the [init field](https://docs.docker.com/compose/compose-file/compose-file-v3/#init), which runs an init process as PID 1 in the container.

The [init process](https://en.wikipedia.org/wiki/Init) in Linux environments is a bit misleading: it's not only responsible for the system's initialization, but also to adopt orphaned process. The lack of this ability may cause what is known by [zombie reaping problem](https://blog.phusion.nl/2015/01/20/docker-and-the-pid-1-zombie-reaping-problem/).

After this change, it's possible to verify that signals are being correctly handled, and as a bonus services take `~ (number of services * 0.4) seconds` to be removed:
```
$ docker compose down
[+] Running 11/10
 ⠿ Container spam          Removed     0.2s
 ⠿ Container grafana       Removed     0.3s
 ⠿ Container prometheus    Removed     0.2s
 ⠿ Container cadvisor      Removed     0.1s
 ⠿ Container tools-peer-2  Removed     0.2s
 ⠿ Container tools-peer-1  Removed     0.4s
 ⠿ Container tools-peer-3  Removed     0.5s
 ⠿ Container tools-peer-4  Removed     0.4s
 ⠿ Container tools-peer-5  Removed     0.4s
 ⠿ Container boot          Removed     0.1s
 ⠿ Network tools_default   Removed     0.1s
```

