### PR TITLE
chore: update observability stack endpoints

### DIFF
--- a/.github/workflows/k8s_e2e_tests.yml
+++ b/.github/workflows/k8s_e2e_tests.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   CERT_SPAMMER_IMAGE: ghcr.io/toposware/cert-spammer:main
-  TELEMETRY_ENDPOINT: jaeger.tce.toposware.com:6831
+  TELEMETRY_ENDPOINT: jaeger.tce.devnet-1.toposware.com:6831
   SPAM_DURATION_SECONDS: 10
   TERRAFORM_INPUTS: >
     -var="cluster_name=${{ github.sha }}"

--- a/tools/docker-compose-prod.yml
+++ b/tools/docker-compose-prod.yml
@@ -1,24 +1,8 @@
 services:
-  jaeger:
-    image: jaegertracing/all-in-one:latest
-    container_name: jaeger
-    restart: always
-    ports:
-      - "6831/udp"
-      - "6832/udp"
-      - "16685"
-      - "16686:16686"
   boot:
     container_name: boot
     image: ghcr.io/toposware/tce:pr-4
     init: true
-    build:
-      context: ../
-      args:
-        - TOOLCHAIN_VERSION=stable
-        - GITHUB_TOKEN
-    depends_on:
-      - jaeger
     ports:
       - "9090"
     environment:
@@ -27,7 +11,7 @@ services:
       - RUST_BACKTRACE=full
       - TCE_LOCAL_KS=1 # 12D3KooWPjceQrSwdWXPyLLeABRXmuqt69Rg3sBYbU1Nft9HyQ6X
       - TCE_JAEGER_SERVICE_NAME=tce-boot-node
-      - TCE_JAEGER_AGENT=jaeger.tce.toposware.com:6831
+      - TCE_JAEGER_AGENT=jaeger.tce.devnet-1.toposware.com:6831
       - TCE_TRBP_ECHO_SAMPLE_SIZE=3
       - TCE_TRBP_READY_SAMPLE_SIZE=3
       - TCE_TRBP_DELIVERY_SAMPLE_SIZE=3
@@ -37,17 +21,12 @@ services:
     logging:
       driver: gelf
       options:
-        gelf-address: "udp://logstash.tce.toposware.com:12201"
+        gelf-address: "udp://logstash.tce.devnet-1.toposware.com:12201"
         tag: "boot"
 
   peer:
     image: ghcr.io/toposware/tce:pr-4
     init: true
-    build:
-      context: ../
-      args:
-        - TOOLCHAIN_VERSION=stable
-        - GITHUB_TOKEN
     ports:
       - "9090"
       - "1340"
@@ -57,7 +36,7 @@ services:
       - RUST_LOG=info,topos_p2p=debug,topos_tce_node_app=debug,topos_tce_protocols_reliable_broadcast=debug
       - TCE_API_ADDR=0.0.0.0:1340
       - TCE_JAEGER_SERVICE_NAME=tce-regular-node
-      - TCE_JAEGER_AGENT=jaeger.tce.toposware.com:6831
+      - TCE_JAEGER_AGENT=jaeger.tce.devnet-1.toposware.com:6831
       - TCE_BOOT_PEERS=12D3KooWPjceQrSwdWXPyLLeABRXmuqt69Rg3sBYbU1Nft9HyQ6X /dns4/boot/tcp/9090
       - TCE_TRBP_ECHO_SAMPLE_SIZE=3
       - TCE_TRBP_READY_SAMPLE_SIZE=3
@@ -70,7 +49,7 @@ services:
     logging:
       driver: gelf
       options:
-        gelf-address: "udp://logstash.tce.toposware.com:12201"
+        gelf-address: "udp://logstash.tce.devnet-1.toposware.com:12201"
         tag: "peer"
 
   cert-spammer:
@@ -81,14 +60,13 @@ services:
       - RUST_LOG=debug
       - TARGET_NODES_PATH=/nodes.json
     depends_on:
-      # - jaeger
       - peer
     volumes:
       - ./peer_nodes.json:/nodes.json
     logging:
       driver: gelf
       options:
-        gelf-address: "udp://logstash.tce.toposware.com:12201"
+        gelf-address: "udp://logstash.tce.devnet-1.toposware.com:12201"
         tag: "cert-spammer"
 
   cadvisor:


### PR DESCRIPTION
## Before
Endpoints related to the TCE observability stack refer to the stack deployed on Azure (accessible from `*.tce.toposware.com`).

## After
Endpoints refer to the new stack on AWS (accessible from `*.tce.devnet-1.toposware.com`).