### PR TITLE
ci: Revert COPY strategy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,35 +6,39 @@ RUN git config --global url."https://${GITHUB_TOKEN}@github.com/".insteadOf "htt
 
 WORKDIR /usr/src/app
 
-COPY . .
-
 FROM base AS planner
+COPY . .
 RUN cargo chef prepare --recipe-path recipe.json
 
 FROM base AS build
 COPY --from=planner /usr/src/app/recipe.json recipe.json
 RUN cargo chef cook --release --recipe-path recipe.json
+COPY . .
 RUN cargo build --release
 
 FROM base AS test
 COPY --from=planner /usr/src/app/recipe.json recipe.json
 RUN cargo chef cook --all-targets --recipe-path recipe.json
+COPY . .
 RUN cargo test --workspace
 
 FROM base AS fmt
 RUN rustup component add rustfmt
+COPY . .
 RUN cargo fmt --all -- --check
 
 FROM base AS lint
 RUN rustup component add clippy
 COPY --from=planner /usr/src/app/recipe.json recipe.json
 RUN cargo chef cook --recipe-path recipe.json
+COPY . .
 RUN cargo clippy --all
 
 FROM base AS audit
 COPY --from=planner /usr/src/app/recipe.json recipe.json
 RUN cargo chef cook --recipe-path recipe.json
 RUN cargo install cargo-audit --locked
+COPY . .
 RUN cargo audit
 
 FROM debian:bullseye-slim


### PR DESCRIPTION
_TL;DR_: Change Docker `COPY` instructions as before #68 was merged

## Before
Currently, building the TCE Docker image produces a malformed binary that once executed, simply exits. 
```
$ docker run --rm -it ghcr.io/toposware/tce:pr-68 bash
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
topos@0300612597b7:/usr/src/app$ ./topos-tce-app 
topos@0300612597b7:/usr/src/app$ echo $?
0

```


Investigating further, it's possible to verify that the binary panics:

```
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: FromEnvError { kind: Env(NotPresent) }', src/tce_node_app.rs:58:49
stack backtrace:
   0: rust_begin_unwind
             at /rustc/897e37553bba8b42751c67658967889d11ecd120/library/std/src/panicking.rs:584:5
   1: core::panicking::panic_fmt
             at /rustc/897e37553bba8b42751c67658967889d11ecd120/library/core/src/panicking.rs:142:14
   2: core::result::unwrap_failed
             at /rustc/897e37553bba8b42751c67658967889d11ecd120/library/core/src/result.rs:1785:5
   3: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
   4: std::thread::local::LocalKey<T>::with
   5: tokio::park::thread::CachedParkThread::block_on
   6: tokio::runtime::scheduler::multi_thread::MultiThread::block_on
   7: tokio::runtime::Runtime::block_on
   8: topos_tce_app::main
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```

## After
The changes from #68 were partially changed. For some reason the `COPY` command causes this error.
The order of instructions were rearranged as it was before and TCE executes as intended.

```
docker run --rm -it ghcr.io/toposware/tce:pr-74 bash
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
topos@e8a11ec02358:/usr/src/app$ ./topos-tce-app 
2022-11-18T23:32:41.182386Z  INFO DoubleEcho::Runtime: topos_tce_broadcast::double_echo: DoubleEcho started
2022-11-18T23:32:41.230830Z DEBUG DiscoveryBehaviour::poll{peer_id=12D3KooWS2k2uqv3j2LK7khgM8HC3m7Nb25Sc2wH92TnfD26ZmuP}: topos_p2p::behaviour::discovery: Discovery => Start providing Key(b"topos-tce")
2022-11-18T23:32:41.238136Z  INFO Runtime::handle_event{peer_id=12D3KooWS2k2uqv3j2LK7khgM8HC3m7Nb25Sc2wH92TnfD26ZmuP}: topos_p2p::runtime::handle_event: Local node is listening on "/ip4/127.0.0.1/tcp/9090/p2p/12D3KooWS2k2uqv3j2LK7khgM8HC3m7Nb25Sc2wH92TnfD26ZmuP"
2022-11-18T23:32:41.239694Z  INFO Runtime::handle_event{peer_id=12D3KooWS2k2uqv3j2LK7khgM8HC3m7Nb25Sc2wH92TnfD26ZmuP}: topos_p2p::runtime::handle_event: Local node is listening on "/ip4/172.17.0.2/tcp/9090/p2p/12D3KooWS2k2uqv3j2LK7khgM8HC3m7Nb25Sc2wH92TnfD26ZmuP"
```

This PR is just a mitigation.

## Follow up
- Find root cause of this issue
