### PR TITLE
feat: adding default implementation for the gatekeeper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3929,6 +3929,7 @@ dependencies = [
  "topos-p2p",
  "topos-tce-api",
  "topos-tce-broadcast",
+ "topos-tce-gatekeeper",
  "topos-tce-storage",
  "topos-tce-transport",
  "tracing",
@@ -3983,6 +3984,14 @@ dependencies = [
  "topos-p2p",
  "topos-tce-transport",
  "tracing",
+]
+
+[[package]]
+name = "topos-tce-gatekeeper"
+version = "0.1.0"
+dependencies = [
+ "futures",
+ "tokio",
 ]
 
 [[package]]

--- a/crates/topos-tce-gatekeeper/Cargo.toml
+++ b/crates/topos-tce-gatekeeper/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "topos-tce-gatekeeper"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+futures.workspace = true
+tokio = { workspace = true, features = ["full"] }

--- a/crates/topos-tce-gatekeeper/src/builder.rs
+++ b/crates/topos-tce-gatekeeper/src/builder.rs
@@ -1,0 +1,35 @@
+use std::{future::IntoFuture, time::Duration};
+
+use futures::{future::BoxFuture, FutureExt};
+use tokio::sync::mpsc;
+
+use crate::{client::GatekeeperClient, Gatekeeper, GatekeeperError};
+
+const DEFAULT_TICK_DURATION: u64 = 10;
+
+pub struct GatekeeperBuilder {}
+
+impl IntoFuture for GatekeeperBuilder {
+    type Output = Result<(GatekeeperClient, Gatekeeper), GatekeeperError>;
+
+    type IntoFuture = BoxFuture<'static, Self::Output>;
+
+    fn into_future(self) -> Self::IntoFuture {
+        let (shutdown_channel, shutdown) = mpsc::channel(1);
+        let (commands, commands_recv) = mpsc::channel(100);
+        let tick_duration = Duration::from_secs(DEFAULT_TICK_DURATION);
+
+        futures::future::ok((
+            GatekeeperClient {
+                shutdown_channel,
+                commands,
+            },
+            Gatekeeper {
+                shutdown,
+                tick_duration,
+                commands: commands_recv,
+            },
+        ))
+        .boxed()
+    }
+}

--- a/crates/topos-tce-gatekeeper/src/client.rs
+++ b/crates/topos-tce-gatekeeper/src/client.rs
@@ -1,0 +1,10 @@
+use tokio::sync::mpsc;
+
+use crate::GatekeeperCommand;
+
+pub struct GatekeeperClient {
+    #[allow(dead_code)]
+    pub(crate) shutdown_channel: mpsc::Sender<()>,
+    #[allow(dead_code)]
+    pub(crate) commands: mpsc::Sender<GatekeeperCommand>,
+}

--- a/crates/topos-tce-gatekeeper/src/lib.rs
+++ b/crates/topos-tce-gatekeeper/src/lib.rs
@@ -1,0 +1,50 @@
+use std::{future::IntoFuture, time::Duration};
+
+use builder::GatekeeperBuilder;
+use futures::{future::BoxFuture, FutureExt};
+use tokio::{sync::mpsc, time};
+
+mod builder;
+mod client;
+
+pub use client::GatekeeperClient;
+
+pub struct Gatekeeper {
+    pub(crate) shutdown: mpsc::Receiver<()>,
+    pub(crate) commands: mpsc::Receiver<GatekeeperCommand>,
+    pub(crate) tick_duration: Duration,
+}
+
+impl IntoFuture for Gatekeeper {
+    type Output = Result<(), GatekeeperError>;
+
+    type IntoFuture = BoxFuture<'static, Self::Output>;
+
+    fn into_future(mut self) -> Self::IntoFuture {
+        async move {
+            let mut interval = time::interval(self.tick_duration);
+
+            loop {
+                tokio::select! {
+                    _ = interval.tick() => {}
+                    _ = self.shutdown.recv() => { break; }
+                    _command = self.commands.recv() => {}
+                }
+            }
+
+            Ok(())
+        }
+        .boxed()
+    }
+}
+
+impl Gatekeeper {
+    #[allow(dead_code)]
+    pub fn builder() -> GatekeeperBuilder {
+        GatekeeperBuilder {}
+    }
+}
+
+#[derive(Debug)]
+pub enum GatekeeperError {}
+pub enum GatekeeperCommand {}

--- a/crates/topos-tce/Cargo.toml
+++ b/crates/topos-tce/Cargo.toml
@@ -20,6 +20,7 @@ tce_transport = { package = "topos-tce-transport", path = "../topos-tce-transpor
 topos-p2p = { path = "../topos-p2p" }
 topos-tce-api = { path = "../topos-tce-api"}
 topos-tce-broadcast = { path = "../topos-tce-broadcast" }
+topos-tce-gatekeeper = { path = "../topos-tce-gatekeeper" }
 
 # external dependencies
 bincode = "1.3.3"

--- a/crates/topos-tce/src/app_context.rs
+++ b/crates/topos-tce/src/app_context.rs
@@ -12,6 +12,7 @@ use topos_tce_api::{RuntimeClient as ApiClient, RuntimeError};
 use topos_tce_broadcast::sampler::SampleType;
 use topos_tce_broadcast::DoubleEchoCommand;
 use topos_tce_broadcast::{ReliableBroadcastClient, SamplerCommand};
+use topos_tce_gatekeeper::GatekeeperClient;
 use topos_tce_storage::events::StorageEvent;
 use topos_tce_storage::StorageClient;
 use tracing::{debug, error, info, trace};
@@ -29,6 +30,7 @@ pub struct AppContext {
     pub network_client: NetworkClient,
     pub api_client: ApiClient,
     pub pending_storage: StorageClient,
+    pub gatekeeper: GatekeeperClient,
 }
 
 impl AppContext {
@@ -38,12 +40,14 @@ impl AppContext {
         trbp_cli: ReliableBroadcastClient,
         network_client: NetworkClient,
         api_client: ApiClient,
+        gatekeeper: GatekeeperClient,
     ) -> Self {
         Self {
             trbp_cli,
             network_client,
             api_client,
             pending_storage,
+            gatekeeper,
         }
     }
 

--- a/crates/topos-tce/src/lib.rs
+++ b/crates/topos-tce/src/lib.rs
@@ -120,8 +120,20 @@ pub async fn run(config: &TceConfiguration) -> Result<(), Box<dyn std::error::Er
 
         spawn(storage.into_future());
 
+        let (gatekeeper_client, gatekeeper_runtime) = topos_tce_gatekeeper::Gatekeeper::builder()
+            .await
+            .expect("Can't create the Gatekeeper");
+
+        spawn(gatekeeper_runtime.into_future());
+
         // setup transport-trbp-storage-api connector
-        let app_context = AppContext::new(storage_client, trbp_cli, network_client, api_client);
+        let app_context = AppContext::new(
+            storage_client,
+            trbp_cli,
+            network_client,
+            api_client,
+            gatekeeper_client,
+        );
 
         app_context
             .run(event_stream, trb_stream, api_stream, storage_stream)


### PR DESCRIPTION
This PR introduces the `Gatekeeper` component, it is just the backbone of the crate and implementation of the logic will be handled in another PR.

Signed-off-by: Freyskeyd <simon.paitrault@gmail.com>