### PR TITLE
fix: rename docker img from topos to tce

### DIFF
--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
+  IMAGE_NAME: toposware/tce
   RUST_TOOLCHAIN_VERSION: stable
 
 jobs:


### PR DESCRIPTION
## Before
With the migration to the `topos` monorepo, packages (docker images) are deployed under the `topos` name (while old packages are under the `tce` name).

## After
New packages are under the `tce` name along the old ones.