### PR TITLE
ci: push multi-arch docker images

### DIFF
--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -45,6 +45,7 @@ jobs:
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |


### PR DESCRIPTION
# Description

This PR adds multi-architecture docker image pushes, to adding ARM support.

## Additions and Changes

### New feature (non-breaking change which adds functionality)

- Add a `platforms: linux/amd64,linux/arm64` line in the docker-push CI workflow to handle multi-architecture

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
