### PR TITLE
fix: docker compose configuration

### DIFF
--- a/tools/docker-compose.yml
+++ b/tools/docker-compose.yml
@@ -114,7 +114,7 @@ services:
 
   cert-spammer:
     container_name: spam
-    image: ghcr.io/toposware/cert-spammer:feature-update-subnet-id
+    image: ghcr.io/toposware/cert-spammer:main
     init: true
     volumes:
       - shared:/tmp/shared


### PR DESCRIPTION
# Description

Fix discrepancies between cert spammer and tce grpc api

### Bug fix (non-breaking change which fixes an issue)

Updated cert spammer image to latest main

## PR Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
