### PR TITLE
feat: switching p2p message to certificate_id

### DIFF
--- a/crates/topos-tce-broadcast/src/lib.rs
+++ b/crates/topos-tce-broadcast/src/lib.rs
@@ -19,7 +19,7 @@ use tokio::sync::{broadcast, mpsc, oneshot};
 use double_echo::DoubleEcho;
 use tce_transport::{ReliableBroadcastParams, TceEvents};
 
-use topos_core::uci::{Certificate, CertificateId, DigestCompressed, SubnetId};
+use topos_core::uci::{Certificate, CertificateId, SubnetId};
 use topos_p2p::PeerId;
 use tracing::{debug, error, info, Span};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
@@ -68,8 +68,7 @@ pub enum DoubleEchoCommand {
     /// Received G-set message
     Deliver {
         from_peer: PeerId,
-        cert: Certificate,
-        digest: DigestCompressed,
+        certificate_id: CertificateId,
         ctx: Context,
     },
 
@@ -87,14 +86,14 @@ pub enum DoubleEchoCommand {
     /// When echo reply received
     Echo {
         from_peer: PeerId,
-        cert: Certificate,
+        certificate_id: CertificateId,
         ctx: Context,
     },
 
     /// When ready reply received
     Ready {
         from_peer: PeerId,
-        cert: Certificate,
+        certificate_id: CertificateId,
         ctx: Context,
     },
     DeliveredCerts {

--- a/crates/topos-tce-transport/src/lib.rs
+++ b/crates/topos-tce-transport/src/lib.rs
@@ -3,7 +3,7 @@
 use clap::Args;
 use opentelemetry::Context;
 use serde::{Deserialize, Serialize};
-use topos_core::uci::{Certificate, DigestCompressed};
+use topos_core::uci::{Certificate, CertificateId};
 use topos_p2p::PeerId;
 use topos_telemetry::PropagationContext;
 
@@ -51,26 +51,22 @@ pub enum TceCommands {
     /// Given peer replied ok to the ReadySubscribe request
     OnReadySubscribeOk { from_peer: PeerId },
     /// Upon new certificate to start delivery
-    OnStartDelivery {
-        cert: Certificate,
-        digest: DigestCompressed,
-    },
+    OnStartDelivery { cert: Certificate },
     /// Received G-set message
     OnGossip {
         cert: Certificate,
-        digest: DigestCompressed,
         ctx: PropagationContext,
     },
     /// When echo reply received
     OnEcho {
         from_peer: PeerId,
-        cert: Certificate,
+        certificate_id: CertificateId,
         ctx: PropagationContext,
     },
     /// When ready reply received
     OnReady {
         from_peer: PeerId,
-        cert: Certificate,
+        certificate_id: CertificateId,
         ctx: PropagationContext,
     },
     /// Given peer replied ok to the double echo request
@@ -97,19 +93,18 @@ pub enum TceEvents {
     Gossip {
         peers: Vec<PeerId>,
         cert: Certificate,
-        digest: DigestCompressed,
         ctx: Context,
     },
     /// Indicates that 'echo' message broadcasting is required
     Echo {
         peers: Vec<PeerId>,
-        cert: Certificate,
+        certificate_id: CertificateId,
         ctx: Context,
     },
     /// Indicates that 'ready' message broadcasting is required
     Ready {
         peers: Vec<PeerId>,
-        cert: Certificate,
+        certificate_id: CertificateId,
         ctx: Context,
     },
     /// For simulation purpose, for now only caused by ill-formed sampling


### PR DESCRIPTION
# Description

This PR aims to reduce the message size of our p2p network by using the `CertificateId` in place of the whole `Certificate`.

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
