### PR TITLE
feat: adding certificate to persist store

### DIFF
--- a/crates/topos-tce-storage/src/connection/handlers.rs
+++ b/crates/topos-tce-storage/src/connection/handlers.rs
@@ -77,8 +77,16 @@ where
 {
     type Error = StorageError;
 
-    async fn handle(&mut self, _command: CertificateDelivered) -> Result<(), StorageError> {
-        Ok(())
+    async fn handle(&mut self, command: CertificateDelivered) -> Result<(), StorageError> {
+        let certificate_id = command.certificate_id;
+
+        let (pending_certificate_id, certificate) =
+            self.storage.get_pending_certificate(certificate_id).await?;
+
+        Ok(self
+            .storage
+            .persist(&certificate, Some(pending_certificate_id))
+            .await?)
     }
 }
 


### PR DESCRIPTION
# Description

When a `Certificate` is delivered, the TCE needs to move it from `pending` to `persisted` storage.

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
