### PR TITLE
feat: reconnect to tce in case of failed stream

### DIFF
--- a/crates/topos-sequencer-types/src/lib.rs
+++ b/crates/topos-sequencer-types/src/lib.rs
@@ -110,6 +110,9 @@ pub enum TceProxyCommand {
 pub enum TceProxyEvent {
     /// New delivered certificate fetched from the TCE network
     NewDeliveredCerts(Vec<Certificate>),
+    /// Failed watching certificates channel
+    /// Requires restart of sequencer tce proxy
+    WatchCertificatesChannelFailed,
 }
 
 // A wrapper to handle all events

--- a/crates/topos-sequencer/src/app_context.rs
+++ b/crates/topos-sequencer/src/app_context.rs
@@ -7,7 +7,7 @@ use topos_sequencer_certification::CertificationWorker;
 use topos_sequencer_subnet_runtime_proxy::SubnetRuntimeProxyWorker;
 use topos_sequencer_tce_proxy::TceProxyWorker;
 use topos_sequencer_types::*;
-use tracing::debug;
+use tracing::{debug, info, warn};
 
 /// Top-level transducer sequencer app context & driver (alike)
 ///
@@ -96,6 +96,35 @@ impl AppContext {
                         .eval(SubnetRuntimeProxyCommand::OnNewDeliveredTxns(cert))
                         .expect("Send cross transactions to the runtime");
                 }
+            }
+            TceProxyEvent::WatchCertificatesChannelFailed => {
+                warn!("Restarting tce proxy worker...");
+                let config = &self.tce_proxy_worker.config;
+                // Here try to restart tce proxy
+                _ = self.tce_proxy_worker.shutdown().await;
+
+                // TODO: Retrieve subnet checkpoint from where to start receiving certificates, again
+                let (tce_proxy_worker, _source_head_certificate_id) = match TceProxyWorker::new(
+                    topos_sequencer_tce_proxy::TceProxyConfig {
+                        subnet_id: config.subnet_id,
+                        base_tce_api_url: config.base_tce_api_url.clone(),
+                        positions: Vec::new(), // TODO acquire from subnet
+                    },
+                )
+                .await
+                {
+                    Ok((tce_proxy_worker, source_head_certificate)) => {
+                        info!("TCE proxy client is restarted for the source subnet {:?} from the head {:?}",config.subnet_id, source_head_certificate);
+                        let source_head_certificate_id =
+                            source_head_certificate.map(|cert| cert.id);
+                        (tce_proxy_worker, source_head_certificate_id)
+                    }
+                    Err(e) => {
+                        panic!("Unable to create TCE Proxy: {e}");
+                    }
+                };
+
+                self.tce_proxy_worker = tce_proxy_worker;
             }
         }
     }

--- a/crates/topos-sequencer/src/lib.rs
+++ b/crates/topos-sequencer/src/lib.rs
@@ -4,7 +4,7 @@ use topos_sequencer_certification::CertificationWorker;
 use topos_sequencer_subnet_runtime_proxy::{SubnetRuntimeProxyConfig, SubnetRuntimeProxyWorker};
 use topos_sequencer_tce_proxy::{TceProxyConfig, TceProxyWorker};
 use topos_sequencer_types::SubnetId;
-use tracing::{error, info};
+use tracing::info;
 
 mod app_context;
 
@@ -47,9 +47,8 @@ pub async fn run(config: SequencerConfiguration) -> Result<(), Box<dyn std::erro
             (tce_proxy_worker, source_head_certificate_id)
         }
         Err(e) => {
-            error!("Error creating tce proxy worker, error: {e}");
             //TODO Handle retry gracefully
-            panic!("Unable to create TCE Proxy");
+            panic!("Unable to create TCE Proxy: {e}");
         }
     };
 


### PR DESCRIPTION
# Description

Restart sequencer tce proxy component if watching certificate channel fails. Connection to tce is opened using retry with backoff algorithm.

Fixes # (issue)
TP-440

## Additions and Changes

In case that channel monitoring certificate pushes from TCE node fails, event `TceProxyEvent::WatchCertificatesChannelFailed` is generated and restart of the tce proxy worker component is perfomed.


## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
