### PR TITLE
fix: change Docker target and push condition

### DIFF
--- a/.github/workflows/docker_utils.yml
+++ b/.github/workflows/docker_utils.yml
@@ -65,12 +65,18 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=schedule,pattern=scheduled-{{date 'YYYYMMDD'}}
+            type=ref,event=branch
+            type=ref,event=tag
+            type=ref,event=pr
 
       - name: Push to GitHub Container Registry
         uses: docker/build-push-action@v3
         with:
           context: .
-          push: true
+          # push only images targeting topos (e.g.: exclude test, lint, etc.)
+          push: ${{ inputs.target == 'topos' }}
           target: ${{ inputs.target }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
# Description

The current Docker build/push is logically wrong: it pushes images regardless of the target stage.
This means that `--target=test`, for example, is also being pushed. This PR fixes the issue, pushing images only when the `--target=topos`.

Also, a couple of tags where changed. Now scheduled runs will have its own tag.


## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
