### PR TITLE
chore: change IAM user and cache args

### DIFF
--- a/.github/workflows/docker_utils.yml
+++ b/.github/workflows/docker_utils.yml
@@ -50,10 +50,10 @@ jobs:
       - name: Configure AWS credentials for cicd-devnet-1 account
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          role-to-assume: arn:aws:iam::367397670706:role/GitHubRole
-          role-session-name: GitHubRole-session
+          aws-access-key-id: ${{ secrets.ROBOT_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.ROBOT_AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: arn:aws:iam::367397670706:role/CacheBucketAccessRole
+          role-session-name: RobotToposware-session
           aws-region: us-east-1
           role-skip-session-tagging: true
           role-duration-seconds: 3600
@@ -91,3 +91,6 @@ jobs:
             TOOLCHAIN_VERSION=${{ inputs.toolchain_version }}
             FEATURES=${{ inputs.features }}
             SCCACHE_S3_KEY_PREFIX=${{ inputs.target }}
+            SCCACHE_BUCKET=cicd-devnet-1-sccache
+            SCCACHE_REGION=us-east-1
+            RUSTC_WRAPPER=/usr/local/cargo/bin/sccache

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,13 @@
 ARG TOOLCHAIN_VERSION
-
 FROM ghcr.io/toposware/rust_builder:1.65-bullseye-${TOOLCHAIN_VERSION} AS base
 
 ARG FEATURES
 ARG GITHUB_TOKEN
-
 # Rust cache
-ARG SCCACHE_S3_KEY_PREFIX=topos
-ENV SCCACHE_BUCKET=cicd-devnet-1-sccache
-ENV SCCACHE_REGION=us-east-1
-ENV RUSTC_WRAPPER=/usr/local/cargo/bin/sccache
+ARG SCCACHE_S3_KEY_PREFIX
+ARG SCCACHE_BUCKET
+ARG SCCACHE_REGION
+ARG RUSTC_WRAPPER
 
 RUN git config --global url."https://${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
 


### PR DESCRIPTION
# Description

- Use `ROBOT_AWS_ACCESS_KEY_ID` and `ROBOT_AWS_SECRET_ACCESS_KEY` to provide access to the `RobotToposware` IAM user
- Assume the `CacheBucketAccessRole` IAM role
- Provide user with args instead of pre defined environment variables in the Dockerfile

## Permissions
The IAM user `Terraform` is being replaced by `RobotToposware`, which can assume roles in the `cicd-devnet-1` account. Following the least privilege principle, it has limited rights on the account: it's able to read-write on the `cicd-devnet-1-sccache` bucket.

### Details
- Created IAM user `RobotToposware` in the `identity` account with `AssumeRole` permission
- Created IAM role `CacheBucketAccessRole` in the `cicd-devnet-1` account, with trust policy that allows `RobotToposware` to assume it
- Created policy with read-write permissions on the `cicd-devnet-1-sccache` s3 bucket
- Associated the above policy with `CacheBucketAccessRole` and `GitHubRole` (legacy: will be replaced by CacheBucketAccessRole. This was done because it was too permissive before)


## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
