### PR TITLE
fix: tarpaulin coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           crate: cargo-tarpaulin
           version: 0.24.0
-      - run: cargo tarpaulin --engine llvm --workspace --all-features --release --exclude topos-sequencer-subnet-runtime-proxy
+      - run: cargo tarpaulin --engine llvm --workspace --features tce,sequencer --release --exclude topos-sequencer-subnet-runtime-proxy
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3.1.1


### PR DESCRIPTION
# Description

The coverage job is failing lastly on the test `buffering_certificates` that needs the double echo, it is about buffering the received Certificate until having stable samples so that we can start broadcasting.

However, if `tce-direct` mode is activated, then the double echo is skipped along with the buffering.

`cargo tarpaulin` is running with `--all-features` including `tce-direct` mode so that may explain why the test is failing.

Note that this fix may be necessary but not sufficient because the `coverage` job used to fail as well before the introduction of the `tce-direct` mode #166 

Fixes TP-505

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] ~~I have commented my code, particularly in hard-to-understand areas~~
- [x] ~~I have made corresponding changes to the documentation~~
- [x] ~~I have added or updated tests that comprehensively prove my change is effective or that my feature works~~
