### PR TITLE
fix: tag images with tce-direct feature accordingly

### DIFF
--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -6,13 +6,11 @@ on:
 
 jobs:
   docker:
-    uses: toposware/topos/.github/workflows/docker_utils.yml@main
+    uses: ./.github/workflows/docker_utils.yml
     secrets: inherit
 
   direct:
-    uses: toposware/topos/.github/workflows/docker_utils.yml@main
+    uses: ./.github/workflows/docker_utils.yml
     secrets: inherit
     with:
       features: "tce-direct,sequencer"
-
-

--- a/.github/workflows/docker_utils.yml
+++ b/.github/workflows/docker_utils.yml
@@ -1,5 +1,10 @@
 name: Docker build and push
 
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+  AWS_SHARED_CREDENTIALS_FILE: "${{ github.workspace }}/.aws/credentials"
+
 on:
   workflow_call:
     inputs:
@@ -17,12 +22,6 @@ on:
         required: false
         type: string
         default: tce,sequencer
-
-
-env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
-  AWS_SHARED_CREDENTIALS_FILE: "${{ github.workspace }}/.aws/credentials"
 
 jobs:
   docker:
@@ -60,9 +59,9 @@ jobs:
 
       - name: Add profile credentials to .aws/credentials
         run: |
-            aws configure set aws_access_key_id ${{ env.AWS_ACCESS_KEY_ID }} --profile default
-            aws configure set aws_secret_access_key ${{ env.AWS_SECRET_ACCESS_KEY }} --profile default
-            aws configure set aws_session_token ${{ env.AWS_SESSION_TOKEN }} --profile default
+          aws configure set aws_access_key_id ${{ env.AWS_ACCESS_KEY_ID }} --profile default
+          aws configure set aws_secret_access_key ${{ env.AWS_SECRET_ACCESS_KEY }} --profile default
+          aws configure set aws_session_token ${{ env.AWS_SESSION_TOKEN }} --profile default
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
@@ -70,10 +69,9 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=schedule,pattern=scheduled-{{date 'YYYYMMDD'}}
-            type=ref,event=branch
-            type=ref,event=tag
-            type=ref,event=pr
+            type=ref,event=branch,suffix=${{ inputs.features == 'tce-direct,sequencer' && '-direct' || ''}}
+            type=ref,event=tag,suffix=${{ inputs.features == 'tce-direct,sequencer' && '-direct' || ''}}
+            type=ref,event=pr,suffix=${{ inputs.features == 'tce-direct,sequencer' && '-direct' || ''}}
 
       - name: Push to GitHub Container Registry
         uses: docker/build-push-action@v3


### PR DESCRIPTION
# Description

#166 introduced a second execution in the `docker_build_push.yml` CI workflow with the `tce-direct` rust feature on. Unfortunately, docker tags were not updated so the last of the two `docker_build_push` executions was overriding the docker image pushed but the first one.

It follows that `topos` docker images are sometimes with `tce` feature, sometimes `tce-direct` (purely depending on which CI run finished last).

This PR updates docker tags produced by the `metadata` docker Github Action so that a `-direct` prefix is added when the job is run with `tce-direct`.

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
