### PR TITLE
fix: include pull request closed event

### DIFF
--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -1,15 +1,9 @@
 name: Docker_build_push
 
 on:
+  push: [main]
   pull_request:
     branches: [main]
-    types:
-      # default
-      - opened
-      - synchronize
-      - reopened
-      # custom
-      - closed
 
 jobs:
   docker:
@@ -23,7 +17,7 @@ jobs:
       features: "tce-direct,sequencer"
 
   k8s_e2e:
-    if: github.event.pull_request.merged
+    if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-latest
     needs: docker
     steps:


### PR DESCRIPTION
# Description

The `Docker_build_push` workflow isn't being triggered on merges into `main`. This is the expected default behavior.

From [GitHub docs page](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request):
<img width="721" alt="Screenshot 2023-03-14 at 3 22 10 PM" src="https://user-images.githubusercontent.com/11741977/225101454-21b8106d-c6e0-47a7-9ac0-ca369bf3185d.png">

~In this PR we Include `closed` event to trigger workflow.~

In this PR we add a `push` trigger.

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
