### PR TITLE
chore: remove unused codecov token

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -36,5 +36,4 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3.1.1
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true


### PR DESCRIPTION
# Description

Remove the CODECOV_TOKEN set for the `coverage.yml` CI workflow. The token is not needed anymore since the repository is now public.

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
