### PR TITLE
fix(init.sh): Add exclusive lock for read/write with jq

### DIFF
--- a/tools/init.sh
+++ b/tools/init.sh
@@ -63,7 +63,7 @@ case "$1" in
            # Acquire lock and add $PEER to ${PEER_LIST_PATH} only once
            (
                flock --exclusive -w 10 201 || exit 1
-               cat <<< $($JQ --arg PEER $PEER '. += [$PEER]|unique' $PEER_LIST_PATH) > $PEER_LIST_PATH
+               cat <<< $($JQ --arg PEER $PEER '. |= (. + [$PEER] | unique )' $PEER_LIST_PATH) > $PEER_LIST_PATH
 
            ) 201>"${PEER_LIST_PATH}.lock"
 


### PR DESCRIPTION
# Description

- Split `jq` command into two
- Add safety check to include content only once


## Bug fix (non-breaking change which fixes an issue)

### Context

We seem to be experiencing some Byzantine Failures with our current stack during initialization. Sometimes launching our stack with Docker compose or K8s works fine, sometimes it fails with:

```
2023-03-24T13:39:55.576090Z DEBUG topos::components::tce: Start executing PushPeerList command
2023-03-24T13:39:55.577121Z DEBUG topos::components::tce: Executing the PushPeerList on the TCE service
Error: Custom { kind: UnexpectedEof, error: Error("EOF while parsing a value", line: 2, column: 0) }
```

This is very likely to be related with the file `peer_ids.json`.

Also, due to the ephemeral nature of containers/pods, restarts are part of their lifecycle. This causes duplicate content in the `peer_ids.json` and `peer_nodes.json` files.

### Hypothesis

The current stack is currently composed by:
- 01 boot node
- 15 peer nodes

Launching them with Docker compose or in a K8s cluster, containers are created (almost) **simultaneously** .
The following line of code in especial will be the subject of this PR:

```
cat <<< $($JQ --arg PEER $PEER '. += [$PEER]' $PEER_LIST_PATH) > $PEER_LIST_PATH
```

The `jq` command **doesn't** provide in-place editing feature like tools such as `sed`. One alternative is the above solution, where:
- `$PEER_LIST_PATH` is read in a command substitution
- output is redirected to `$PEER_LIST_PATH`

During the `stdout` redirection, the `$PEER_LIST_PATH` file is [truncated to zero-length](https://www.gnu.org/software/bash/manual/bash.html#Redirecting-Output) and only then content is written.

The concurrency between containers/pods trying to read/write to the same file may cause a situation where `container A` reads `$PEER_LIST_PATH` while `container B` truncates `$PEER_LIST_PATH` .

### Proposal
The proposal here is to instead:

```
           # Acquire lock and add $PEER to ${PEER_LIST_PATH} only once
           (
               flock --exclusive 200
               cat <<< $($JQ --arg PEER $PEER '. += [$PEER]|unique' $PEER_LIST_PATH) > $PEER_LIST_PATH

           ) 200>/tmp/shared/"${PEER_LIST_PATH}.lock"
```

1. Redirect stdout of subshell to `"${PEER_LIST_PATH}.lock"` through fd `200`
2. Acquire exclusive lock for fd `200` (inherited from parent process)
3. Use `unique` to add content only once



## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
