### PR TITLE
fix: mount credentials on cargo audit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,8 @@ RUN --mount=type=secret,id=aws,target=/root/.aws/credentials \
   cargo clippy --all --tests
 
 FROM base AS audit
-RUN cargo install cargo-audit --locked
+RUN --mount=type=secret,id=aws,target=/root/.aws/credentials \
+  cargo install cargo-audit --locked
 COPY . .
 RUN cargo audit
 


### PR DESCRIPTION
# Description

Same as #193 , except now the fix is for:
- `cargo install cargo-audit --locked`

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
