### PR TITLE
chore: rename topos-network to topos-protocol

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
-* @topos-network/protocol
+* @topos-protocol/protocol
 
 # Crypto Internals
 
-/crates/topos-crypto/ @topos-network/protocol @topos-network/crypto @Nashtare
+/crates/topos-crypto/ @topos-protocol/protocol @topos-protocol/crypto @Nashtare

--- a/.github/workflows/grpc-client-stubs.yml
+++ b/.github/workflows/grpc-client-stubs.yml
@@ -27,7 +27,7 @@ jobs:
           cache: npm
           cache-dependency-path: ./crates/topos-api/proto/package-lock.json
           registry-url: https://registry.npmjs.org
-          scope: "@topos-network"
+          scope: "@topos-protocol"
 
       - name: Install grpc-tool globally
         run: npm install -g grpc-tools
@@ -61,7 +61,7 @@ jobs:
         uses: EndBug/version-check@v2
         with:
           file-name: ./crates/topos-api/proto/package.json
-          file-url: https://unpkg.com/@topos-network/topos-grpc-client-stub@latest/package.json
+          file-url: https://unpkg.com/@topos-protocol/topos-grpc-client-stub@latest/package.json
           static-checking: localIsNew
 
       - name: Check coverage tolerance

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Checkout topos-smart-contracts repo
         uses: actions/checkout@v3
         with:
-          repository: topos-network/topos-smart-contracts
+          repository: topos-protocol/topos-smart-contracts
           ref: ${{ env.CONTRACTS_REF }}
           path: contracts
 

--- a/.github/workflows/sequencer_topos_core_contract_test.yml
+++ b/.github/workflows/sequencer_topos_core_contract_test.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: convictional/trigger-workflow-and-wait@v1.6.1
         with:
-          owner: topos-network
+          owner: topos-protocol
           repo: e2e-tests
           github_token: ${{ secrets.ROBOT_PAT_TRIGGER_E2E_WORKFLOWS }}
           workflow_file_name: topos:sequencer-contracts.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG TOOLCHAIN_VERSION
-FROM --platform=${BUILDPLATFORM:-linux/amd64} ghcr.io/topos-network/rust_builder:bullseye-${TOOLCHAIN_VERSION} AS base
+FROM --platform=${BUILDPLATFORM:-linux/amd64} ghcr.io/topos-protocol/rust_builder:bullseye-${TOOLCHAIN_VERSION} AS base
 
 ARG FEATURES
 # Rust cache

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ topos is the unified command line interface to the <a href="https://docs.toposwa
 
 <!-- **`topos` is the unified command line interface to the [Topos](https://docs.toposware.com/general-overview) network.** -->
 
-[![codecov](https://codecov.io/gh/topos-network/topos/branch/main/graph/badge.svg?token=FOH2B2GRL9&style=flat)](https://codecov.io/gh/topos-network/topos)
-![Test workflow](https://github.com/topos-network/topos/actions/workflows/test.yml/badge.svg)
-![Quality workflow](https://github.com/topos-network/topos/actions/workflows/quality.yml/badge.svg)
+[![codecov](https://codecov.io/gh/topos-protocol/topos/branch/main/graph/badge.svg?token=FOH2B2GRL9&style=flat)](https://codecov.io/gh/topos-protocol/topos)
+![Test workflow](https://github.com/topos-protocol/topos/actions/workflows/test.yml/badge.svg)
+![Quality workflow](https://github.com/topos-protocol/topos/actions/workflows/quality.yml/badge.svg)
 ![MSRV](https://img.shields.io/badge/MSRV-1.64-blue?labelColor=1C2C2E&logo=Rust&style=flat-square)
 
 ## Getting Started
@@ -32,7 +32,7 @@ The first step is to install Rust along with `cargo` by following the instructio
 **Install `topos`**
 
 ```
-cargo install topos --git https://github.com/topos-network/topos
+cargo install topos --git https://github.com/topos-protocol/topos
 ```
 
 **Try out `topos`!**
@@ -45,12 +45,12 @@ Find more about how topos works in the [documentation](https://docs.toposware.co
 
 ## Development
 
-Contributions are very welcomed, the guidelines are outlined in [`CONTRIBUTING.md`](https://github.com/topos-network/.github/blob/main/CONTRIBUTING.md).<br />
+Contributions are very welcomed, the guidelines are outlined in [`CONTRIBUTING.md`](https://github.com/topos-protocol/.github/blob/main/CONTRIBUTING.md).<br />
 Running a minimal local setup with docker compose is described [here](./tools/README.md).
 
 ## Support
 
-Feel free to [open an issue](https://github.com/topos-network/topos/issues/new) if you have any feature request or bug report.<br />
+Feel free to [open an issue](https://github.com/topos-protocol/topos/issues/new) if you have any feature request or bug report.<br />
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 <br />
 
 <p align="center">
-topos is the unified command line interface to the <a href="https://docs.toposware.com/general-overview">Topos</a> network.
+topos is the unified command line interface to the <a href="https://docs.toposware.com/general-overview">Topos</a> protocol.
 </p>
 
 <br />

--- a/crates/topos-api/proto/package-lock.json
+++ b/crates/topos-api/proto/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@topos-network/topos-grpc-client-stub",
+  "name": "@topos-protocol/topos-grpc-client-stub",
   "version": "0.1.0-rc2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@topos-network/topos-grpc-client-stub",
+      "name": "@topos-protocol/topos-grpc-client-stub",
       "version": "0.1.0-rc2",
       "license": "MIT",
       "devDependencies": {

--- a/crates/topos-api/proto/package.json
+++ b/crates/topos-api/proto/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@topos-network/topos-grpc-client-stub",
+  "name": "@topos-protocol/topos-grpc-client-stub",
   "version": "0.1.2",
   "description": "JavaScript gRPC client stub for topos-api",
   "files": [
@@ -7,7 +7,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/topos-network/topos.git"
+    "url": "git+https://github.com/topos-protocol/topos.git"
   },
   "keywords": [
     "grpc",
@@ -20,9 +20,9 @@
   "author": "Sebastien Dan <sebastien.dan@gmail.com>",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/topos-network/topos/issues"
+    "url": "https://github.com/topos-protocol/topos/issues"
   },
-  "homepage": "https://github.com/topos-network/topos#readme",
+  "homepage": "https://github.com/topos-protocol/topos#readme",
   "devDependencies": {
     "grpc_tools_node_protoc_ts": "^5.3.3"
   }

--- a/crates/topos-sequencer-subnet-client/src/subnet_contract.rs
+++ b/crates/topos-sequencer-subnet-client/src/subnet_contract.rs
@@ -9,7 +9,7 @@ use ethers::{
 use std::sync::Arc;
 use tracing::info;
 
-abigen!(IToposCore, "npm:@topos-network/topos-smart-contracts@latest/artifacts/contracts/interfaces/IToposCore.sol/IToposCore.json");
+abigen!(IToposCore, "npm:@topos-protocol/topos-smart-contracts@latest/artifacts/contracts/interfaces/IToposCore.sol/IToposCore.json");
 
 pub(crate) fn create_topos_core_contract_from_json<T: Middleware>(
     contract_address: &str,

--- a/crates/topos-sequencer-subnet-runtime/tests/subnet_contract.rs
+++ b/crates/topos-sequencer-subnet-runtime/tests/subnet_contract.rs
@@ -32,7 +32,7 @@ use topos_test_sdk::constants::*;
 const SUBNET_RPC_PORT: u32 = 8545;
 const TEST_SECRET_ETHEREUM_KEY: &str =
     "d7e2e00b43c12cf17239d4755ed744df6ca70a933fc7c8bbb7da1342a5ff2e38";
-const POLYGON_EDGE_CONTAINER: &str = "ghcr.io/topos-network/polygon-edge";
+const POLYGON_EDGE_CONTAINER: &str = "ghcr.io/topos-protocol/polygon-edge";
 const POLYGON_EDGE_CONTAINER_TAG: &str = "develop";
 const SUBNET_STARTUP_DELAY: u64 = 5; // seconds left for subnet startup
 const TEST_SUBNET_ID: &str = "6464646464646464646464646464646464646464646464646464646464646464";

--- a/crates/topos/src/components/setup/commands/subnet.rs
+++ b/crates/topos/src/components/setup/commands/subnet.rs
@@ -15,7 +15,7 @@ pub struct Subnet {
     #[arg(
         long,
         env = "TOPOS_SETUP_SUBNET_REPOSITORY",
-        default_value = "topos-network/polygon-edge"
+        default_value = "topos-protocol/polygon-edge"
     )]
     pub repository: String,
     /// List all available Polygon Edge release versions without installation

--- a/tools/docker-compose.yml
+++ b/tools/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   boot:
     container_name: boot
     command: boot tce run
-    image: ghcr.io/topos-network/topos:main
+    image: ghcr.io/topos-protocol/topos:main
     init: true
     labels:
       "autoheal": "true"
@@ -34,7 +34,7 @@ services:
       - TCE_LOCAL_KS=1 # 12D3KooWRhFCXBhmsMnur3up3vJsDoqWh4c39PKXgSWwzAzDHNLn
 
   peer:
-    image: ghcr.io/topos-network/topos:main
+    image: ghcr.io/topos-protocol/topos:main
     command: peer tce run
     init: true
     labels:
@@ -68,7 +68,7 @@ services:
   spammer:
     container_name: spam
     command: network spam
-    image: ghcr.io/topos-network/topos:main
+    image: ghcr.io/topos-protocol/topos:main
     init: true
     build:
       context: ../
@@ -89,7 +89,7 @@ services:
 
   check:
     container_name: check
-    image: ghcr.io/topos-network/topos:main
+    image: ghcr.io/topos-protocol/topos:main
     command: tce push-certificate -f json
     profiles:
       - CI


### PR DESCRIPTION
# Description

Simple changes in consequence of the organization renaming to `topos-protocol`
