### PR TITLE
fix: prune the buffers after transfer

### DIFF
--- a/crates/topos-tce-broadcast/src/task_manager_channels/mod.rs
+++ b/crates/topos-tce-broadcast/src/task_manager_channels/mod.rs
@@ -118,6 +118,7 @@ impl TaskManager {
                 }
             }
 
+            // Transfer the buffers to the newly existing tasks
             for (certificate_id, messages) in &mut self.buffered_messages {
                 if let Some(task) = self.tasks.get(certificate_id) {
                     for msg in messages {
@@ -125,6 +126,10 @@ impl TaskManager {
                     }
                 }
             }
+
+            // Prune the transferred buffers
+            self.buffered_messages
+                .retain(|c, _| self.tasks.get_mut(c).is_none());
         }
     }
 }

--- a/crates/topos-tce-broadcast/src/task_manager_futures/mod.rs
+++ b/crates/topos-tce-broadcast/src/task_manager_futures/mod.rs
@@ -132,6 +132,7 @@ impl TaskManager {
                 }
             }
 
+            // Transfer the buffers to the newly existing tasks
             for (certificate_id, messages) in &mut self.buffered_messages {
                 if let Some(task) = self.tasks.get_mut(certificate_id) {
                     for msg in messages {
@@ -139,6 +140,10 @@ impl TaskManager {
                     }
                 }
             }
+
+            // Prune the transferred buffers
+            self.buffered_messages
+                .retain(|c, _| self.tasks.get_mut(c).is_none());
         }
     }
 }


### PR DESCRIPTION
# Description

Fix by pruning the applied buffers once transferred to the related task

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
