### PR TITLE
fix: remove buffered messages when creating a new task

### DIFF
--- a/crates/topos-tce-broadcast/src/task_manager_channels/mod.rs
+++ b/crates/topos-tce-broadcast/src/task_manager_channels/mod.rs
@@ -94,6 +94,12 @@ impl TaskManager {
 
                                     spawn(task.run());
 
+                                    if let Some(messages) = self.buffered_messages.remove(&cert.id) {
+                                        for msg in messages {
+                                            _ = task_context.sink.send(msg).await;
+                                        }
+                                    }
+
                                     entry.insert(task_context);
                                 }
                                 std::collections::hash_map::Entry::Occupied(_) => {},
@@ -115,14 +121,6 @@ impl TaskManager {
                     }
 
                     break;
-                }
-            }
-
-            for (certificate_id, messages) in &mut self.buffered_messages {
-                if let Some(task) = self.tasks.get(certificate_id) {
-                    for msg in messages {
-                        _ = task.sink.send(msg.clone()).await;
-                    }
                 }
             }
         }


### PR DESCRIPTION
### Bug fix (non-breaking change which fixes an issue)

Fixes the increasing size of buffered messages by removing them right when creating a new task.

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
