### PR TITLE
chore: adding dummy proof size for spammer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6726,6 +6726,7 @@ dependencies = [
  "clap 4.3.11",
  "futures",
  "hex",
+ "lazy_static",
  "opentelemetry",
  "rand 0.8.5",
  "rand_core 0.6.4",

--- a/crates/topos-certificate-spammer/Cargo.toml
+++ b/crates/topos-certificate-spammer/Cargo.toml
@@ -20,6 +20,7 @@ tracing-opentelemetry.workspace = true
 opentelemetry.workspace = true
 tiny-keccak.workspace = true
 uuid.workspace = true
+lazy_static.workspace = true
 
 toml = "0.5.9"
 

--- a/crates/topos-certificate-spammer/src/utils.rs
+++ b/crates/topos-certificate-spammer/src/utils.rs
@@ -2,6 +2,10 @@ use topos_core::uci::{Certificate, SubnetId};
 
 use crate::{error::Error, SourceSubnet};
 
+lazy_static::lazy_static! {
+    static ref PROOF_SIZE: usize = std::env::var("PROOF_SIZE_KB").map(|v| v.parse::<usize>().unwrap_or(0)).unwrap_or(0) * 1024;
+}
+
 pub fn generate_random_32b_array() -> [u8; 32] {
     (0..32)
         .map(|_| rand::random::<u8>())
@@ -22,7 +26,7 @@ pub fn generate_test_certificate(
         generate_random_32b_array(),
         target_subnet_ids,
         0,
-        Vec::new(),
+        vec![254u8; *PROOF_SIZE],
     )?;
     new_cert
         .update_signature(&source_subnet.signing_key)

--- a/crates/topos-certificate-spammer/src/utils.rs
+++ b/crates/topos-certificate-spammer/src/utils.rs
@@ -3,7 +3,18 @@ use topos_core::uci::{Certificate, SubnetId};
 use crate::{error::Error, SourceSubnet};
 
 lazy_static::lazy_static! {
-    static ref PROOF_SIZE: usize = std::env::var("PROOF_SIZE_KB").map(|v| v.parse::<usize>().unwrap_or(0)).unwrap_or(0) * 1024;
+    /// Size of the proof
+    static ref PROOF_SIZE_BYTES: usize =
+        std::env::var("TOPOS_PROOF_SIZE_BYTES")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(1000);
+
+    /// Dummy proof with specified size
+    static ref STARK_BLOB: Vec<u8> =
+        (0..*PROOF_SIZE_BYTES)
+           .map(|_| rand::random::<u8>())
+           .collect::<Vec<u8>>();
 }
 
 pub fn generate_random_32b_array() -> [u8; 32] {
@@ -26,7 +37,7 @@ pub fn generate_test_certificate(
         generate_random_32b_array(),
         target_subnet_ids,
         0,
-        vec![254u8; *PROOF_SIZE],
+        STARK_BLOB.clone(),
     )?;
     new_cert
         .update_signature(&source_subnet.signing_key)


### PR DESCRIPTION
# Description

This PR adds a dummy way to define proof size usable in the spammer for benchmarks and tests.
It listens for a `PROOF_SIZE_KB` that will be used when generating the certificate proof as `[254u8; PROOF_SIZE]`

## PR Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
