### PR TITLE
fix: use instant instead of systemtime

### DIFF
--- a/crates/topos-tce-broadcast/src/double_echo/broadcast_state.rs
+++ b/crates/topos-tce-broadcast/src/double_echo/broadcast_state.rs
@@ -22,7 +22,7 @@ pub struct BroadcastState {
     ready_threshold: usize,
     delivery_threshold: usize,
     event_sender: mpsc::Sender<ProtocolEvents>,
-    delivery_time: time::SystemTime,
+    delivery_time: time::Instant,
 }
 
 impl BroadcastState {
@@ -43,7 +43,7 @@ impl BroadcastState {
             ready_threshold,
             delivery_threshold,
             event_sender,
-            delivery_time: time::SystemTime::now(),
+            delivery_time: time::Instant::now(),
         };
 
         _ = state.event_sender.try_send(ProtocolEvents::Broadcast {
@@ -122,7 +122,7 @@ impl BroadcastState {
             );
             // Calculate delivery time
             let from = self.delivery_time;
-            let duration = from.elapsed().unwrap();
+            let duration = from.elapsed();
             let d = duration;
 
             info!(


### PR DESCRIPTION
### Bug fix (non-breaking change which fixes an issue)

Switch `SystemTime` for `Instant`, since `SystemTime` can error out and is dealing with real world times.

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
