### PR TITLE
feat: propagate all the args for edge and update tce/sequencer config

### DIFF
--- a/crates/topos-sequencer/src/lib.rs
+++ b/crates/topos-sequencer/src/lib.rs
@@ -22,7 +22,7 @@ pub struct SequencerConfiguration {
     pub public_key: Option<Vec<u8>>,
     pub subnet_jsonrpc_endpoint: String,
     pub subnet_contract_address: String,
-    pub base_tce_api_url: String,
+    pub tce_grpc_endpoint: String,
     pub signing_key: SecretKey,
     pub verifier: u32,
 }
@@ -98,7 +98,7 @@ pub async fn launch(
     // TODO: Revise this approach?
     let (tce_proxy_worker, source_head_certificate_id) = match TceProxyWorker::new(TceProxyConfig {
         subnet_id,
-        base_tce_api_url: config.base_tce_api_url.clone(),
+        base_tce_api_url: config.tce_grpc_endpoint.clone(),
         positions: target_subnet_stream_positions,
     })
     .await

--- a/crates/topos/src/components/node/mod.rs
+++ b/crates/topos/src/components/node/mod.rs
@@ -24,7 +24,7 @@ use tokio::{
 use tokio_util::sync::CancellationToken;
 use topos_p2p::config::NetworkConfig;
 use topos_tce_transport::ReliableBroadcastParams;
-use tracing::{error, info};
+use tracing::{debug, error, info};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 
 use self::commands::{NodeCommand, NodeCommands};
@@ -133,7 +133,6 @@ pub(crate) async fn handle_command(
 
             // FIXME: Handle properly the `cmd`
             let config = NodeConfig::new(&node_path, None);
-            println!("EdgeConfig: {:?}", config.edge);
             info!(
                 "⚙️ Reading the configuration from {}/{}/config.toml",
                 home.display(),
@@ -184,10 +183,8 @@ pub(crate) async fn handle_command(
 
             // TCE
             if config.base.subnet_id == "topos" {
-                let mut tce_config = config.tce.clone().unwrap();
-                tce_config.db_path = node_path.join(tce_config.db_path);
                 processes.push(services::spawn_tce_process(
-                    tce_config,
+                    config.tce.clone().unwrap(),
                     keys,
                     genesis,
                     (shutdown_token.clone(), shutdown_sender.clone()),

--- a/crates/topos/src/components/node/mod.rs
+++ b/crates/topos/src/components/node/mod.rs
@@ -165,7 +165,7 @@ pub(crate) async fn handle_command(
             let mut processes = FuturesUnordered::new();
 
             // Edge
-            let data_dir = node_path;
+            let data_dir = node_path.clone();
             processes.push(services::spawn_edge_process(
                 edge_path.join(BINARY_NAME),
                 data_dir,
@@ -184,8 +184,10 @@ pub(crate) async fn handle_command(
 
             // TCE
             if config.base.subnet_id == "topos" {
+                let mut tce_config = config.tce.clone().unwrap();
+                tce_config.db_path = node_path.join(tce_config.db_path);
                 processes.push(services::spawn_tce_process(
-                    config.tce.clone().unwrap(),
+                    tce_config,
                     keys,
                     genesis,
                     (shutdown_token.clone(), shutdown_sender.clone()),

--- a/crates/topos/src/components/node/mod.rs
+++ b/crates/topos/src/components/node/mod.rs
@@ -133,7 +133,7 @@ pub(crate) async fn handle_command(
 
             // FIXME: Handle properly the `cmd`
             let config = NodeConfig::new(&node_path, None);
-
+            println!("EdgeConfig: {:?}", config.edge);
             info!(
                 "⚙️ Reading the configuration from {}/{}/config.toml",
                 home.display(),
@@ -153,8 +153,6 @@ pub(crate) async fn handle_command(
                 None => SecretManager::from_fs(node_path.clone()),
             };
 
-            let data_dir = node_path.join(config.edge.clone().unwrap().subnet_data_dir);
-
             info!(
                 "🧢 New joiner: {} for the \"{}\" subnet as {:?}",
                 config.base.name, config.base.subnet_id, config.base.role
@@ -167,10 +165,12 @@ pub(crate) async fn handle_command(
             let mut processes = FuturesUnordered::new();
 
             // Edge
+            let data_dir = node_path;
             processes.push(services::spawn_edge_process(
                 edge_path.join(BINARY_NAME),
                 data_dir,
                 genesis.path.clone(),
+                config.edge.unwrap().args,
             ));
 
             // Sequencer

--- a/crates/topos/src/components/node/services.rs
+++ b/crates/topos/src/components/node/services.rs
@@ -23,7 +23,7 @@ use topos_sequencer::SequencerConfiguration;
 use topos_tce::config::{AuthKey, StorageConfiguration, TceConfiguration};
 use topos_tce_transport::ReliableBroadcastParams;
 use topos_wallet::SecretManager;
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 
 use crate::config::genesis::Genesis;
 
@@ -77,6 +77,7 @@ pub(crate) fn spawn_sequencer_process(
         verifier: 0,
     };
 
+    debug!("Sequencer args: {config:?}");
     spawn(async move {
         topos_sequencer::run(config, shutdown).await.map_err(|e| {
             error!("Failure on the Sequencer: {e:?}");
@@ -112,6 +113,7 @@ pub(crate) fn spawn_tce_process(
         version: env!("TOPOS_VERSION"),
     };
 
+    debug!("TCE args: {tce_config:?}");
     spawn(async move {
         topos_tce::run(&tce_config, shutdown).await.map_err(|e| {
             error!("TCE process terminated: {e:?}");
@@ -126,6 +128,7 @@ pub fn spawn_edge_process(
     genesis_path: PathBuf,
     edge_args: HashMap<String, String>,
 ) -> JoinHandle<Result<(), Errors>> {
+    debug!("Edge args: {edge_args:?}");
     spawn(async move {
         match CommandConfig::new(edge_path)
             .server(&data_dir, &genesis_path, edge_args)

--- a/crates/topos/src/components/node/services.rs
+++ b/crates/topos/src/components/node/services.rs
@@ -3,6 +3,7 @@ use crate::config::sequencer::SequencerConfig;
 use crate::config::tce::TceConfig;
 use crate::edge::{CommandConfig, BINARY_NAME};
 use opentelemetry::global;
+use std::collections::HashMap;
 use std::error::Error;
 use std::future::Future;
 use std::path::{Path, PathBuf};
@@ -41,6 +42,8 @@ pub fn generate_edge_config(
     config_path: PathBuf,
 ) -> JoinHandle<Result<(), Errors>> {
     // Create the Polygon Edge config
+    info!("Generating the configuration at {config_path:?}");
+    info!("Polygon-edge binary located at: {edge_path:?}");
     spawn(async move {
         match CommandConfig::new(edge_path)
             .init(&config_path)
@@ -121,10 +124,11 @@ pub fn spawn_edge_process(
     edge_path: PathBuf,
     data_dir: PathBuf,
     genesis_path: PathBuf,
+    edge_args: HashMap<String, String>,
 ) -> JoinHandle<Result<(), Errors>> {
     spawn(async move {
         match CommandConfig::new(edge_path)
-            .server(&data_dir, &genesis_path)
+            .server(&data_dir, &genesis_path, edge_args)
             .spawn()
             .await
         {

--- a/crates/topos/src/components/node/services.rs
+++ b/crates/topos/src/components/node/services.rs
@@ -69,10 +69,9 @@ pub(crate) fn spawn_sequencer_process(
         public_key: keys.validator_pubkey(),
         subnet_jsonrpc_endpoint: config.subnet_jsonrpc_endpoint,
         subnet_contract_address: config.subnet_contract_address,
-        // TODO: Merge with or default to config.tce.tce_local_port?
-        base_tce_api_url: config.base_tce_api_url,
+        tce_grpc_endpoint: config.tce_grpc_endpoint,
         signing_key: keys.validator.clone().unwrap(),
-        verifier: config.verifier,
+        verifier: 0,
     };
 
     spawn(async move {

--- a/crates/topos/src/components/node/services.rs
+++ b/crates/topos/src/components/node/services.rs
@@ -104,7 +104,7 @@ pub(crate) fn spawn_tce_process(
         api_addr: config.grpc_api_addr,
         graphql_api_addr: config.graphql_api_addr,
         metrics_api_addr: config.metrics_api_addr,
-        storage: StorageConfiguration::RocksDB(PathBuf::from_str(&config.db_path).ok()),
+        storage: StorageConfiguration::RocksDB(Some(config.db_path)),
         network_bootstrap_timeout: Duration::from_secs(10),
         minimum_cluster_size: config
             .minimum_tce_cluster_size

--- a/crates/topos/src/components/sequencer/mod.rs
+++ b/crates/topos/src/components/sequencer/mod.rs
@@ -23,7 +23,7 @@ pub(crate) async fn handle_command(
                 public_key: None,
                 subnet_jsonrpc_endpoint: cmd.subnet_jsonrpc_endpoint,
                 subnet_contract_address: cmd.subnet_contract_address,
-                base_tce_api_url: cmd.base_tce_api_url,
+                tce_grpc_endpoint: cmd.base_tce_api_url,
                 signing_key: keys.validator.clone().unwrap(),
                 verifier: cmd.verifier,
             };

--- a/crates/topos/src/config/base.rs
+++ b/crates/topos/src/config/base.rs
@@ -11,6 +11,7 @@ use crate::config::node::NodeRole;
 use crate::config::Config;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "kebab-case")]
 pub struct BaseConfig {
     #[serde(default = "default_name")]
     pub name: String,

--- a/crates/topos/src/config/edge.rs
+++ b/crates/topos/src/config/edge.rs
@@ -1,4 +1,7 @@
-use std::path::{Path, PathBuf};
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+};
 
 use crate::config::Config;
 use figment::{
@@ -9,34 +12,14 @@ use serde::{Deserialize, Serialize};
 
 use crate::components::subnet::commands::Run;
 
+// TODO: Provides the default arguments here
+// Serde `flatten` and `default` doesn't work together yet
+// https://github.com/serde-rs/serde/issues/1626
+
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct EdgeConfig {
-    /// SubnetId of the local subnet node, hex encoded 32 bytes starting with 0x
-    pub subnet_id: Option<String>,
-
-    // Core contract address
-    #[serde(default = "default_subnet_contract_address")]
-    pub subnet_contract_address: String,
-
-    /// Base Uri of TCE node to call grpc service api
-    #[serde(default = "default_base_tce_api_url")]
-    pub base_tce_api_url: String,
-
-    /// Polygon subnet node data dir, containing `consensus/validator.key`, e.g. `../test-chain-1`
-    #[serde(default = "default_subnet_data_dir")]
-    pub subnet_data_dir: PathBuf,
-}
-
-fn default_subnet_contract_address() -> String {
-    "0x0000000000000000000000000000000000000000".to_string()
-}
-
-fn default_base_tce_api_url() -> String {
-    "http://[::1]:1340".to_string()
-}
-
-fn default_subnet_data_dir() -> PathBuf {
-    PathBuf::from("./test-chain-1")
+    #[serde(flatten)]
+    pub args: HashMap<String, String>,
 }
 
 impl Config for EdgeConfig {

--- a/crates/topos/src/config/edge.rs
+++ b/crates/topos/src/config/edge.rs
@@ -15,8 +15,8 @@ use crate::components::subnet::commands::Run;
 // TODO: Provides the default arguments here
 // Serde `flatten` and `default` doesn't work together yet
 // https://github.com/serde-rs/serde/issues/1626
-
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "kebab-case")]
 pub struct EdgeConfig {
     #[serde(flatten)]
     pub args: HashMap<String, String>,

--- a/crates/topos/src/config/mod.rs
+++ b/crates/topos/src/config/mod.rs
@@ -76,8 +76,8 @@ pub(crate) fn load_config<T: Config>(node_path: &Path, command: Option<T::Comman
             println!("Missing field: {}", name);
             std::process::exit(1);
         }
-        _ => {
-            println!("Failed to load config");
+        Err(e) => {
+            println!("Failed to load config: {e}");
             std::process::exit(1);
         }
     }

--- a/crates/topos/src/config/node.rs
+++ b/crates/topos/src/config/node.rs
@@ -34,7 +34,7 @@ impl NodeConfig {
     pub fn new(from: &Path, cmd: Option<node::commands::Init>) -> Self {
         let base = load_config::<BaseConfig>(from, cmd);
 
-        Self {
+        let mut config = NodeConfig {
             base: base.clone(),
             sequencer: base
                 .need_sequencer()
@@ -45,7 +45,14 @@ impl NodeConfig {
             edge: base
                 .need_edge()
                 .then(|| load_config::<EdgeConfig>(from, None)),
+        };
+
+        // Make the TCE DB path relative to the folder
+        if let Some(config) = config.tce.as_mut() {
+            config.db_path = from.join(&config.db_path);
         }
+
+        config
     }
 }
 

--- a/crates/topos/src/config/node.rs
+++ b/crates/topos/src/config/node.rs
@@ -27,7 +27,6 @@ pub(crate) struct NodeConfig {
     pub(crate) base: BaseConfig,
     pub(crate) tce: Option<TceConfig>,
     pub(crate) sequencer: Option<SequencerConfig>,
-    #[serde(rename = "subnet")]
     pub(crate) edge: Option<EdgeConfig>,
 }
 

--- a/crates/topos/src/config/sequencer.rs
+++ b/crates/topos/src/config/sequencer.rs
@@ -10,37 +10,25 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct SequencerConfig {
-    /// SubnetId of the local subnet node, hex encoded 32 bytes starting with 0x
+    /// SubnetId of your Sequencer, hex encoded 32 bytes prefixed with 0x
     pub subnet_id: Option<String>,
 
-    // Subnet endpoint in the form [ip address]:[port]
-    // Topos sequencer expects both websocket and http protocol available
-    // on this subnet endpoint
+    /// JSON-RPC endpoint of the Edge node, websocket and http support expected
     #[serde(default = "default_subnet_jsonrpc_endpoint")]
     pub subnet_jsonrpc_endpoint: String,
 
-    // Core contract address
+    /// Address where the Topos Core contract is deployed
     #[serde(default = "default_subnet_contract_address")]
     pub subnet_contract_address: String,
 
-    /// Base Uri of TCE node to call grpc service api
-    #[serde(default = "default_base_tce_api_url")]
-    pub base_tce_api_url: String,
+    /// gRPC API endpoint of one TCE process
+    #[serde(default = "default_tce_grpc_endpoint")]
+    pub tce_grpc_endpoint: String,
 
-    /// Polygon subnet node data dir, containing `consensus/validator.key`, e.g. `../test-chain-1`
-    #[serde(default = "default_subnet_data_dir")]
-    pub subnet_data_dir: PathBuf,
-
-    /// Verifier version
-    #[serde(default = "default_verifier")]
-    pub verifier: u32,
-
-    /// Socket of the opentelemetry agent endpoint
-    /// If not provided open telemetry will not be used
+    /// OTLP agent endpoint, not used if not provided
     pub otlp_agent: Option<String>,
 
-    /// Otlp service name
-    /// If not provided open telemetry will not be used
+    /// OTLP service name, not used if not provided
     pub otlp_service_name: Option<String>,
 }
 
@@ -52,16 +40,8 @@ fn default_subnet_contract_address() -> String {
     "0x0000000000000000000000000000000000000000".to_string()
 }
 
-fn default_base_tce_api_url() -> String {
+fn default_tce_grpc_endpoint() -> String {
     "http://[::1]:1340".to_string()
-}
-
-fn default_subnet_data_dir() -> PathBuf {
-    PathBuf::from("../test-chain-1")
-}
-
-fn default_verifier() -> u32 {
-    0
 }
 
 impl Config for SequencerConfig {

--- a/crates/topos/src/config/sequencer.rs
+++ b/crates/topos/src/config/sequencer.rs
@@ -9,6 +9,7 @@ use figment::{
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "kebab-case")]
 pub struct SequencerConfig {
     /// SubnetId of your Sequencer, hex encoded 32 bytes prefixed with 0x
     pub subnet_id: Option<String>,

--- a/crates/topos/src/config/tce.rs
+++ b/crates/topos/src/config/tce.rs
@@ -1,5 +1,5 @@
-use std::net::SocketAddr;
 use std::path::Path;
+use std::{net::SocketAddr, path::PathBuf};
 
 use figment::{
     providers::{Format, Serialized, Toml},
@@ -12,10 +12,11 @@ use crate::config::Config;
 use topos_p2p::{Multiaddr, PeerId};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "kebab-case")]
 pub struct TceConfig {
     /// Storage database path, if not set RAM storage is used
     #[serde(default = "default_db_path")]
-    pub db_path: String,
+    pub db_path: PathBuf,
     /// Array of extra boot nodes to connect to
     pub extra_boot_peers: Option<String>,
     /// Ip for the p2p Multiaddr
@@ -43,8 +44,8 @@ pub struct TceConfig {
     pub otlp_service_name: Option<String>,
 }
 
-fn default_db_path() -> String {
-    "./default_db/".to_string()
+fn default_db_path() -> PathBuf {
+    PathBuf::from("./tce_rocksdb")
 }
 
 fn default_grpc_api_addr() -> SocketAddr {

--- a/crates/topos/src/edge/mod.rs
+++ b/crates/topos/src/edge/mod.rs
@@ -44,13 +44,23 @@ impl CommandConfig {
         self
     }
 
-    pub fn server(mut self, data_dir: &Path, genesis_path: &Path) -> Self {
+    pub fn server(
+        mut self,
+        data_dir: &Path,
+        genesis_path: &Path,
+        edge_args: HashMap<String, String>,
+    ) -> Self {
         self.args.push("server".into());
         self.args.push("--data-dir".into());
         self.args.push(format!("{}", data_dir.display()));
         self.args.push("--chain".into());
         self.args.push(format!("{}", genesis_path.display()));
         self.args.push("--json".into());
+
+        for (k, v) in &edge_args {
+            self.args.push(format!("--{k}"));
+            self.args.push(v.to_string());
+        }
 
         self
     }

--- a/crates/topos/tests/config.rs
+++ b/crates/topos/tests/config.rs
@@ -52,7 +52,7 @@ async fn test_handle_command_init() -> Result<(), Box<dyn std::error::Error>> {
 
     assert!(config_contents.contains("[base]"));
     assert!(config_contents.contains("name = \"default\""));
-    assert!(config_contents.contains("[subnet]"));
+    assert!(config_contents.contains("[edge]"));
     assert!(config_contents.contains("[tce]"));
 
     std::fs::remove_dir_all(temporary_test_folder)?;


### PR DESCRIPTION
# Description

- propagate all the args for Edge
- moved to kebab-case
- prune `verifier` and `data-dir` for the sequencer configuration which are not useful anymore
- change default directory for the tce db
- rename `base_tce_api_url` to `tce-grpc-endpoint`
- renamed the subnet toml profile to edge so that it is explicit that it is about the Edge arguments

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
