### PR TITLE
fix: port discrepencies tce/edge bootnode

### DIFF
--- a/crates/topos-p2p/src/constant.rs
+++ b/crates/topos-p2p/src/constant.rs
@@ -27,3 +27,6 @@ lazy_static! {
 pub const TRANSMISSION_PROTOCOL: &str = "/tce-transmission/1";
 pub const DISCOVERY_PROTOCOL: &str = "/tce-disco/1";
 pub const PEER_INFO_PROTOCOL: &str = "/tce-peer-info/1";
+
+// FIXME: Considered as constant until customizable and exposed properly in the genesis file
+pub const TCE_BOOTNODE_PORT: u16 = 9090;

--- a/crates/topos-sequencer-subnet-runtime/tests/subnet_contract.rs
+++ b/crates/topos-sequencer-subnet-runtime/tests/subnet_contract.rs
@@ -1,3 +1,5 @@
+#![allow(unknown_lints)]
+#![allow(hidden_glob_reexports)]
 use dockertest::{
     Composition, DockerTest, Image, LogAction, LogOptions, LogPolicy, LogSource, PullPolicy, Source,
 };

--- a/crates/topos-tce/src/lib.rs
+++ b/crates/topos-tce/src/lib.rs
@@ -44,12 +44,16 @@ pub async fn run(
 
     let addr: Multiaddr = format!("/ip4/0.0.0.0/tcp/{}", config.tce_local_port).parse()?;
 
+    // Remove myself from the bootnode list
+    let mut boot_peers = config.boot_peers.clone();
+    boot_peers.retain(|(p, _)| *p != peer_id);
+
     let (network_client, event_stream, unbootstrapped_runtime) = topos_p2p::network::builder()
         .peer_key(key)
         .listen_addr(addr)
         .minimum_cluster_size(config.minimum_cluster_size)
         .exposed_addresses(external_addr)
-        .known_peers(&config.boot_peers)
+        .known_peers(&boot_peers)
         .build()
         .await?;
 

--- a/crates/topos/src/components/node/services.rs
+++ b/crates/topos/src/components/node/services.rs
@@ -94,13 +94,13 @@ pub(crate) fn spawn_tce_process(
 ) -> JoinHandle<Result<(), Errors>> {
     let tce_config = TceConfiguration {
         boot_peers: genesis
-            .boot_peers()
+            .boot_peers(Some(topos_p2p::constant::TCE_BOOTNODE_PORT))
             .into_iter()
             .chain(config.parse_boot_peers())
             .collect::<Vec<_>>(),
         auth_key: keys.network.map(AuthKey::PrivateKey),
-        tce_addr: "/ip4/0.0.0.0".into(), // FIXME: to remove, no need to be exposed
-        tce_local_port: 0,               // FIXME: to remove, no need to be exposed
+        tce_addr: format!("/ip4/{}", config.libp2p_api_addr.ip()),
+        tce_local_port: config.libp2p_api_addr.port(),
         tce_params: ReliableBroadcastParams::new(genesis.validator_count()),
         api_addr: config.grpc_api_addr,
         graphql_api_addr: config.graphql_api_addr,

--- a/crates/topos/src/components/node/services.rs
+++ b/crates/topos/src/components/node/services.rs
@@ -106,7 +106,7 @@ pub(crate) fn spawn_tce_process(
         graphql_api_addr: config.graphql_api_addr,
         metrics_api_addr: config.metrics_api_addr,
         storage: StorageConfiguration::RocksDB(Some(config.db_path)),
-        network_bootstrap_timeout: Duration::from_secs(10),
+        network_bootstrap_timeout: Duration::from_secs(180),
         minimum_cluster_size: config
             .minimum_tce_cluster_size
             .unwrap_or(NetworkConfig::MINIMUM_CLUSTER_SIZE),

--- a/crates/topos/src/config/genesis/mod.rs
+++ b/crates/topos/src/config/genesis/mod.rs
@@ -32,13 +32,21 @@ impl Genesis {
     }
 
     // TODO: parse directly with serde
-    pub fn boot_peers(&self) -> Vec<(PeerId, Multiaddr)> {
+    pub fn boot_peers(&self, port: Option<u16>) -> Vec<(PeerId, Multiaddr)> {
         match self.json["bootnodes"].as_array() {
             Some(v) => v
                 .iter()
                 .map(|bootnode| {
                     let (multiaddr, peerid) =
                         bootnode.as_str().unwrap().rsplit_once("/p2p/").unwrap();
+
+                    // Extract the Edge port from the genesis file
+                    let (multiaddr, edge_port) = multiaddr.rsplit_once('/').unwrap();
+
+                    // Use the given port instead if any
+                    let port = port.map_or(edge_port.to_string(), |p| p.to_string());
+
+                    let multiaddr = format!("{multiaddr}/{port}");
                     (peerid.parse().unwrap(), multiaddr.parse().unwrap())
                 })
                 .collect::<Vec<_>>(),

--- a/crates/topos/src/config/genesis/tests.rs
+++ b/crates/topos/src/config/genesis/tests.rs
@@ -22,7 +22,7 @@ pub fn test_correct_validator_count(genesis: &Genesis) {
 
 #[rstest]
 pub fn test_parse_bootnodes(genesis: &Genesis) {
-    let bootnodes = genesis.boot_peers();
+    let bootnodes = genesis.boot_peers(None);
 
     assert_eq!(4, bootnodes.len());
 }

--- a/crates/topos/src/config/tce.rs
+++ b/crates/topos/src/config/tce.rs
@@ -28,6 +28,9 @@ pub struct TceConfig {
     /// Connection degree for the GossipSub overlay
     pub minimum_tce_cluster_size: Option<usize>,
     /// gRPC API Addr
+    #[serde(default = "default_libp2p_api_addr")]
+    pub libp2p_api_addr: SocketAddr,
+    /// gRPC API Addr
     #[serde(default = "default_grpc_api_addr")]
     pub grpc_api_addr: SocketAddr,
     /// GraphQL API Addr
@@ -46,6 +49,12 @@ pub struct TceConfig {
 
 fn default_db_path() -> PathBuf {
     PathBuf::from("./tce_rocksdb")
+}
+
+fn default_libp2p_api_addr() -> SocketAddr {
+    "0.0.0.0:9090"
+        .parse()
+        .expect("Cannot parse address to SocketAddr")
 }
 
 fn default_grpc_api_addr() -> SocketAddr {


### PR DESCRIPTION
# Description

Decouple the port for Edge and TCE bootnodes

**Important**
The port for the TCE bootnode is hardcoded to `9090` until we expose the `Multiaddr` of the TCE bootnodes properly on the genesis file aside the ones for the Edge nodes.

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
