### PR TITLE
feat: adding get certificate by id graphql endpoint

### DIFF
--- a/crates/topos-api/src/graphql/certificate.rs
+++ b/crates/topos-api/src/graphql/certificate.rs
@@ -51,28 +51,3 @@ impl From<topos_uci::SubnetId> for SubnetId {
         }
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::CertificateId;
-
-    const CERTIFICATE_ID_WITH_PREFIX: &str =
-        "0x11db8713a79c41625f4bb2221bd43ac4766fff23e78f82212f48713a6768e76a";
-    const CERTIFICATE_ID_WITHOUT_PREFIX: &str =
-        "11db8713a79c41625f4bb2221bd43ac4766fff23e78f82212f48713a6768e76a";
-    const MALFORMATTED_CERTIFICATE_ID: &str = "invalid_hex_string";
-
-    #[test]
-    fn convert_cert_id_string_with_prefix() {
-        let certificate_id1: CertificateId = CERTIFICATE_ID_WITH_PREFIX.to_string().into();
-
-        assert_eq!(
-            &certificate_id1.id[..],
-            &[
-                0x11, 0xdb, 0x87, 0x13, 0xa7, 0x9c, 0x41, 0x62, 0x5f, 0x4b, 0xb2, 0x22, 0x1b, 0xd4,
-                0x3a, 0xc4, 0x76, 0x6f, 0xff, 0x23, 0xe7, 0x8f, 0x82, 0x21, 0x2f, 0x48, 0x71, 0x3a,
-                0x67, 0x68, 0xe7, 0x6a
-            ][..]
-        )
-    }
-}

--- a/crates/topos-api/src/graphql/certificate.rs
+++ b/crates/topos-api/src/graphql/certificate.rs
@@ -19,6 +19,7 @@ pub struct Certificate {
     pub state_root: String,
     pub target_subnets: Vec<SubnetId>,
     pub tx_root_hash: String,
+    pub receipts_root_hash: String,
     pub verifier: u32,
 }
 
@@ -37,6 +38,7 @@ impl From<topos_uci::Certificate> for Certificate {
                 .map(SubnetId::from)
                 .collect(),
             tx_root_hash: hex::encode(uci_cert.tx_root_hash),
+            receipts_root_hash: "0x".to_string() + &hex::encode(uci_cert.receipts_root_hash),
             verifier: uci_cert.verifier,
         }
     }
@@ -47,5 +49,30 @@ impl From<topos_uci::SubnetId> for SubnetId {
         SubnetId {
             value: uci_id.to_string(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::CertificateId;
+
+    const CERTIFICATE_ID_WITH_PREFIX: &str =
+        "0x11db8713a79c41625f4bb2221bd43ac4766fff23e78f82212f48713a6768e76a";
+    const CERTIFICATE_ID_WITHOUT_PREFIX: &str =
+        "11db8713a79c41625f4bb2221bd43ac4766fff23e78f82212f48713a6768e76a";
+    const MALFORMATTED_CERTIFICATE_ID: &str = "invalid_hex_string";
+
+    #[test]
+    fn convert_cert_id_string_with_prefix() {
+        let certificate_id1: CertificateId = CERTIFICATE_ID_WITH_PREFIX.to_string().into();
+
+        assert_eq!(
+            &certificate_id1.id[..],
+            &[
+                0x11, 0xdb, 0x87, 0x13, 0xa7, 0x9c, 0x41, 0x62, 0x5f, 0x4b, 0xb2, 0x22, 0x1b, 0xd4,
+                0x3a, 0xc4, 0x76, 0x6f, 0xff, 0x23, 0xe7, 0x8f, 0x82, 0x21, 0x2f, 0x48, 0x71, 0x3a,
+                0x67, 0x68, 0xe7, 0x6a
+            ][..]
+        )
     }
 }

--- a/crates/topos-api/src/graphql/certificate.rs
+++ b/crates/topos-api/src/graphql/certificate.rs
@@ -38,7 +38,7 @@ impl From<topos_uci::Certificate> for Certificate {
                 .map(SubnetId::from)
                 .collect(),
             tx_root_hash: hex::encode(uci_cert.tx_root_hash),
-            receipts_root_hash: "0x".to_string() + &hex::encode(uci_cert.receipts_root_hash),
+            receipts_root_hash: format!("0x{}", hex::encode(uci_cert.receipts_root_hash)),
             verifier: uci_cert.verifier,
         }
     }

--- a/crates/topos-api/src/graphql/errors.rs
+++ b/crates/topos-api/src/graphql/errors.rs
@@ -4,6 +4,8 @@ pub enum GraphQLServerError {
     ParseDataConnector,
     #[error("The provided subnet_id is not a proper HEX value")]
     ParseSubnetId,
+    #[error("The provided certificate_id is not a proper HEX value")]
+    ParseCertificateId,
     #[error("Internal Server Error")]
     StorageError,
 }

--- a/crates/topos-api/src/graphql/query.rs
+++ b/crates/topos-api/src/graphql/query.rs
@@ -1,4 +1,4 @@
-use crate::graphql::certificate::Certificate;
+use crate::graphql::certificate::{Certificate, CertificateId};
 use crate::graphql::checkpoint::SourceCheckpoint;
 use crate::graphql::errors::GraphQLServerError;
 
@@ -12,4 +12,9 @@ pub trait CertificateQuery {
         from_source_checkpoint: SourceCheckpoint,
         first: usize,
     ) -> Result<Vec<Certificate>, GraphQLServerError>;
+
+    async fn certificate_by_id(
+        ctx: &Context<'_>,
+        certificate_id: CertificateId,
+    ) -> Result<Certificate, GraphQLServerError>;
 }

--- a/crates/topos-api/src/grpc/conversions/uci/v1/uci.rs
+++ b/crates/topos-api/src/grpc/conversions/uci/v1/uci.rs
@@ -13,6 +13,7 @@ impl TryFrom<proto_v1::Certificate> for topos_uci::Certificate {
                 .prev_id
                 .expect("valid previous certificate id")
                 .value
+                .as_slice()
                 .try_into()
                 .expect("valid previous certificate id with correct length"),
             source_subnet_id: certificate
@@ -44,6 +45,7 @@ impl TryFrom<proto_v1::Certificate> for topos_uci::Certificate {
                 .id
                 .expect("valid certificate id")
                 .value
+                .as_slice()
                 .try_into()
                 .expect("valid certificate id with correct length"),
             proof: certificate.proof.expect("valid proof").value,

--- a/crates/topos-tce-api/src/graphql/query.rs
+++ b/crates/topos-tce-api/src/graphql/query.rs
@@ -83,4 +83,12 @@ impl QueryRoot {
     ) -> Result<Vec<Certificate>, GraphQLServerError> {
         Self::certificates_per_subnet(ctx, from_source_checkpoint, first).await
     }
+
+    async fn certificate(
+        &self,
+        ctx: &Context<'_>,
+        certificate_id: CertificateId,
+    ) -> Result<Certificate, GraphQLServerError> {
+        Self::certificate_by_id(ctx, certificate_id).await
+    }
 }

--- a/crates/topos-tce-api/src/graphql/query.rs
+++ b/crates/topos-tce-api/src/graphql/query.rs
@@ -70,7 +70,7 @@ impl CertificateQuery for QueryRoot {
                     .value
                     .as_bytes()
                     .try_into()
-                    .expect("Cannot convert String to CertificateId"),
+                    .map_err(|_| GraphQLServerError::ParseCertificateId)?,
             )
             .await
             .map_err(|_| GraphQLServerError::StorageError)

--- a/crates/topos-tce-api/src/graphql/query.rs
+++ b/crates/topos-tce-api/src/graphql/query.rs
@@ -65,7 +65,7 @@ impl CertificateQuery for QueryRoot {
         })?;
 
         storage
-            .get_certificate(certificate_id.into())
+            .get_certificate(certificate_id.value.into())
             .await
             .map_err(|_| GraphQLServerError::StorageError)
             .map(|c| c.into())

--- a/crates/topos-tce-api/src/graphql/query.rs
+++ b/crates/topos-tce-api/src/graphql/query.rs
@@ -65,7 +65,13 @@ impl CertificateQuery for QueryRoot {
         })?;
 
         storage
-            .get_certificate(certificate_id.value.into())
+            .get_certificate(
+                certificate_id
+                    .value
+                    .as_bytes()
+                    .try_into()
+                    .expect("Cannot convert String to CertificateId"),
+            )
             .await
             .map_err(|_| GraphQLServerError::StorageError)
             .map(|c| c.into())

--- a/crates/topos-tce-api/tests/runtime.rs
+++ b/crates/topos-tce-api/tests/runtime.rs
@@ -556,6 +556,7 @@ async fn can_query_graphql_endpoint_for_certificates() {
                     value
                 }}
                 txRootHash
+                receiptsRootHash
                 verifier
             }}
         }}

--- a/crates/topos-uci/src/certificate_id.rs
+++ b/crates/topos-uci/src/certificate_id.rs
@@ -62,8 +62,8 @@ impl TryFrom<Vec<u8>> for CertificateId {
 
 impl From<String> for CertificateId {
     fn from(input: String) -> Self {
-        let id = if input.starts_with("0x") {
-            hex::decode(&input[2..]).unwrap_or_else(|_| vec![0u8; CERTIFICATE_ID_LENGTH])
+        let id = if let Some(stripped) = input.strip_prefix("0x") {
+            hex::decode(stripped).unwrap_or_else(|_| vec![0u8; CERTIFICATE_ID_LENGTH])
         } else {
             hex::decode(&input).unwrap_or_else(|_| vec![0u8; CERTIFICATE_ID_LENGTH])
         };
@@ -71,7 +71,7 @@ impl From<String> for CertificateId {
         let id_array: [u8; CERTIFICATE_ID_LENGTH] = id
             .as_slice()
             .try_into()
-            .unwrap_or_else(|_| [0u8; CERTIFICATE_ID_LENGTH]);
+            .unwrap_or([0u8; CERTIFICATE_ID_LENGTH]);
 
         CertificateId { id: id_array }
     }

--- a/crates/topos-uci/src/certificate_id.rs
+++ b/crates/topos-uci/src/certificate_id.rs
@@ -60,6 +60,23 @@ impl TryFrom<Vec<u8>> for CertificateId {
     }
 }
 
+impl From<String> for CertificateId {
+    fn from(input: String) -> Self {
+        let id = if input.starts_with("0x") {
+            hex::decode(&input[2..]).unwrap_or_else(|_| vec![0u8; CERTIFICATE_ID_LENGTH])
+        } else {
+            hex::decode(&input).unwrap_or_else(|_| vec![0u8; CERTIFICATE_ID_LENGTH])
+        };
+
+        let id_array: [u8; CERTIFICATE_ID_LENGTH] = id
+            .as_slice()
+            .try_into()
+            .unwrap_or_else(|_| [0u8; CERTIFICATE_ID_LENGTH]);
+
+        CertificateId { id: id_array }
+    }
+}
+
 impl CertificateId {
     pub const fn from_array(id: [u8; CERTIFICATE_ID_LENGTH]) -> Self {
         Self { id }
@@ -67,5 +84,57 @@ impl CertificateId {
 
     pub const fn as_array(&self) -> &[u8; CERTIFICATE_ID_LENGTH] {
         &self.id
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    const CERTIFICATE_ID_WITH_PREFIX: &str =
+        "0x11db8713a79c41625f4bb2221bd43ac4766fff23e78f82212f48713a6768e76a";
+    const CERTIFICATE_ID_WITHOUT_PREFIX: &str =
+        "11db8713a79c41625f4bb2221bd43ac4766fff23e78f82212f48713a6768e76a";
+    const MALFORMATTED_CERTIFICATE_ID: &str = "invalid_hex_string";
+
+    #[test]
+    fn convert_cert_id_string_with_prefix() {
+        let certificate_id1: CertificateId = CERTIFICATE_ID_WITH_PREFIX.to_string().into();
+
+        assert_eq!(
+            &certificate_id1.id[..],
+            &[
+                0x11, 0xdb, 0x87, 0x13, 0xa7, 0x9c, 0x41, 0x62, 0x5f, 0x4b, 0xb2, 0x22, 0x1b, 0xd4,
+                0x3a, 0xc4, 0x76, 0x6f, 0xff, 0x23, 0xe7, 0x8f, 0x82, 0x21, 0x2f, 0x48, 0x71, 0x3a,
+                0x67, 0x68, 0xe7, 0x6a
+            ][..]
+        )
+    }
+
+    #[test]
+    fn convert_cert_id_string_without_prefix() {
+        let certificate_id1: CertificateId = CERTIFICATE_ID_WITHOUT_PREFIX.to_string().into();
+
+        assert_eq!(
+            &certificate_id1.id[..],
+            &[
+                0x11, 0xdb, 0x87, 0x13, 0xa7, 0x9c, 0x41, 0x62, 0x5f, 0x4b, 0xb2, 0x22, 0x1b, 0xd4,
+                0x3a, 0xc4, 0x76, 0x6f, 0xff, 0x23, 0xe7, 0x8f, 0x82, 0x21, 0x2f, 0x48, 0x71, 0x3a,
+                0x67, 0x68, 0xe7, 0x6a
+            ][..]
+        )
+    }
+
+    #[test]
+    fn malformatted_cert_id() {
+        let certificate_id3: CertificateId = MALFORMATTED_CERTIFICATE_ID.to_string().into();
+
+        assert_eq!(
+            &certificate_id3.id[..],
+            &[
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                0x00, 0x00, 0x00, 0x00,
+            ][..]
+        )
     }
 }

--- a/crates/topos-uci/src/certificate_id.rs
+++ b/crates/topos-uci/src/certificate_id.rs
@@ -97,40 +97,41 @@ mod tests {
 
     #[test]
     fn convert_cert_id_string_with_prefix() {
-        let certificate_id: CertificateId =
-            CertificateId::try_from(CERTIFICATE_ID_WITH_PREFIX.as_bytes())
-                .expect("Cannot convert to CertificateID");
+        let certificate_id: CertificateId = CERTIFICATE_ID_WITH_PREFIX
+            .as_bytes()
+            .try_into()
+            .expect("Cannot convert to CertificateID");
 
-        assert_eq!(
-            &certificate_id.id[..],
-            &[
-                0x11, 0xdb, 0x87, 0x13, 0xa7, 0x9c, 0x41, 0x62, 0x5f, 0x4b, 0xb2, 0x22, 0x1b, 0xd4,
-                0x3a, 0xc4, 0x76, 0x6f, 0xff, 0x23, 0xe7, 0x8f, 0x82, 0x21, 0x2f, 0x48, 0x71, 0x3a,
-                0x67, 0x68, 0xe7, 0x6a
-            ][..]
-        )
+        let expected_bytes: &[u8] = &[
+            0x11, 0xdb, 0x87, 0x13, 0xa7, 0x9c, 0x41, 0x62, 0x5f, 0x4b, 0xb2, 0x22, 0x1b, 0xd4,
+            0x3a, 0xc4, 0x76, 0x6f, 0xff, 0x23, 0xe7, 0x8f, 0x82, 0x21, 0x2f, 0x48, 0x71, 0x3a,
+            0x67, 0x68, 0xe7, 0x6a,
+        ];
+
+        assert_eq!(certificate_id.id.as_slice(), expected_bytes)
     }
 
     #[test]
     fn convert_cert_id_string_without_prefix() {
-        let certificate_id: CertificateId =
-            CertificateId::try_from(MALFORMATTED_CERTIFICATE_ID.as_bytes())
-                .expect("Cannot convert to CertificateID");
+        let certificate_id: &[u8] =
+            &hex::decode(CERTIFICATE_ID_WITHOUT_PREFIX).expect("Cannot convert to CertificateI");
 
-        assert_eq!(
-            &certificate_id.id[..],
-            &[
-                0x11, 0xdb, 0x87, 0x13, 0xa7, 0x9c, 0x41, 0x62, 0x5f, 0x4b, 0xb2, 0x22, 0x1b, 0xd4,
-                0x3a, 0xc4, 0x76, 0x6f, 0xff, 0x23, 0xe7, 0x8f, 0x82, 0x21, 0x2f, 0x48, 0x71, 0x3a,
-                0x67, 0x68, 0xe7, 0x6a
-            ][..]
-        )
+        let certificate_id: CertificateId = certificate_id
+            .try_into()
+            .expect("Cannot transform bytes to CertificateId");
+
+        let expected_bytes: &[u8] = &[
+            0x11, 0xdb, 0x87, 0x13, 0xa7, 0x9c, 0x41, 0x62, 0x5f, 0x4b, 0xb2, 0x22, 0x1b, 0xd4,
+            0x3a, 0xc4, 0x76, 0x6f, 0xff, 0x23, 0xe7, 0x8f, 0x82, 0x21, 0x2f, 0x48, 0x71, 0x3a,
+            0x67, 0x68, 0xe7, 0x6a,
+        ];
+
+        assert_eq!(certificate_id.id.as_slice(), expected_bytes)
     }
 
     #[test]
-    #[should_panic]
     fn malformatted_cert_id() {
-        let certificate_id = CertificateId::try_from(CERTIFICATE_ID_WITHOUT_PREFIX.as_bytes());
+        let certificate_id = CertificateId::try_from(MALFORMATTED_CERTIFICATE_ID.as_bytes());
 
         assert!(certificate_id.is_err());
     }

--- a/crates/topos-uci/src/certificate_id.rs
+++ b/crates/topos-uci/src/certificate_id.rs
@@ -89,7 +89,8 @@ impl CertificateId {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::CertificateId;
+
     const CERTIFICATE_ID_WITH_PREFIX: &str =
         "0x11db8713a79c41625f4bb2221bd43ac4766fff23e78f82212f48713a6768e76a";
     const CERTIFICATE_ID_WITHOUT_PREFIX: &str =

--- a/crates/topos-uci/src/lib.rs
+++ b/crates/topos-uci/src/lib.rs
@@ -17,6 +17,7 @@ mod certificate_id;
 mod subnet_id;
 
 pub const CERTIFICATE_ID_LENGTH: usize = 32;
+pub const HEX_CERTIFICATE_ID_LENGTH: usize = 64;
 pub const SUBNET_ID_LENGTH: usize = 32;
 
 pub type StarkProof = Vec<u8>;


### PR DESCRIPTION
# Description

Adding a GraphQL endpoint to fetch a single certificate by id.

## Query
```graphql
query Certificate {
    certificate(certificateId: {value: "0xf6c3482c85f8110e228214837baa3aaa3cdd75428d9f3527774728c5972d5050"}) {
        id
        prevId
        proof
        signature
        sourceSubnetId
        stateRoot
        txRootHash
        receiptsRootHash
        verifier
    }
}
```

## Result
```json
{
    "data": {
        "certificate": {
            "id": "0xf6c3482c85f8110e228214837baa3aaa3cdd75428d9f3527774728c5972d5050",
            "prevId": "0xd892f5ac52ebce5740cb7f9fc34d3196b14fb82f9fe657c8330353950af0b3b4",
            "proof": "",
            "signature": "ea6288f1a26ae3dac993fdf90a3463696765c44605858e154bcc05199cd4165d6ced5d4c25fa87fed92b01da051516375e8e1b563f628bac01c645c0faa925e0",
            "sourceSubnetId": "0x58ba876abdaf89c8796486923d179514afe7153f3da95bdad8f08ced777bfa4c",
            "stateRoot": "17cf915fc05f47cab417e5ba6c7dfae8fb9337c333f74cbdd19cf4be392725d9",
            "txRootHash": "56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
            "receiptsRootHash": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
            "verifier": 0
        }
    }
}
```

Fixes TP-689

## Additions and Changes

Adding one GraphQL endpoint

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
