### PR TITLE
feat: add sync from genesis block

### DIFF
--- a/crates/topos-sequencer-subnet-client/src/lib.rs
+++ b/crates/topos-sequencer-subnet-client/src/lib.rs
@@ -21,8 +21,7 @@ pub use topos_core::uci::{
     Address, Certificate, CertificateId, ReceiptsRootHash, StateRoot, SubnetId, TxRootHash,
     CERTIFICATE_ID_LENGTH, SUBNET_ID_LENGTH,
 };
-use tracing::log::warn;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
 const PUSH_CERTIFICATE_GAS_LIMIT: u64 = 1000000;
 
@@ -140,8 +139,8 @@ impl SubnetClientListener {
             .map_err(Error::EthersProviderError)?;
 
         info!(
-            "Next wanted block number: {} latest subnet block number: {}",
-            next_block_number, next_block_number
+            "Finalized block number: next={} and latest={}",
+            next_block_number, latest_subnet_block_number
         );
 
         if latest_subnet_block_number.as_u64() < next_block_number {
@@ -162,16 +161,15 @@ impl SubnetClientListener {
             Err(Error::EventDecodingError(e)) => {
                 // WARN: Happens in block before subnet contract is deployed, seems like bug in ethers
                 warn!(
-                    "Unable to parse events from block {}, error: {}",
-                    block_number, e
+                    "Unable to parse events from block {}, error: {e}",
+                    block_number
                 );
                 Vec::new()
             }
             Err(e) => {
                 error!(
-                    "Unable to parse events from block {}, error: {}",
-                    block_number,
-                    e.to_string()
+                    "Unable to parse events from block {}, error: {e}",
+                    block_number
                 );
                 return Err(e);
             }

--- a/crates/topos-sequencer-subnet-client/src/lib.rs
+++ b/crates/topos-sequencer-subnet-client/src/lib.rs
@@ -21,7 +21,7 @@ pub use topos_core::uci::{
     Address, Certificate, CertificateId, ReceiptsRootHash, StateRoot, SubnetId, TxRootHash,
     CERTIFICATE_ID_LENGTH, SUBNET_ID_LENGTH,
 };
-use tracing::{error, info, warn};
+use tracing::{error, info};
 
 const PUSH_CERTIFICATE_GAS_LIMIT: u64 = 1000000;
 
@@ -159,18 +159,12 @@ impl SubnetClientListener {
         let events = match get_block_events(&self.contract, block_number).await {
             Ok(events) => events,
             Err(Error::EventDecodingError(e)) => {
-                // WARN: Happens in block before subnet contract is deployed, seems like bug in ethers
-                warn!(
-                    "Unable to parse events from block {}, error: {e}",
-                    block_number
-                );
+                // FIXME: Happens in block before subnet contract is deployed, seems like bug in ethers
+                error!("Unable to parse events from block {}: {e}", block_number);
                 Vec::new()
             }
             Err(e) => {
-                error!(
-                    "Unable to parse events from block {}, error: {e}",
-                    block_number
-                );
+                error!("Unable to parse events from block {}: {e}", block_number);
                 return Err(e);
             }
         };

--- a/crates/topos-sequencer-subnet-client/src/subnet_contract.rs
+++ b/crates/topos-sequencer-subnet-client/src/subnet_contract.rs
@@ -33,8 +33,7 @@ pub(crate) async fn get_block_events(
     let topos_core_events = events.query_with_meta().await.map_err(|e| {
         match e {
             ContractError::DecodingError(e) => {
-                // WARN: events have decoding error in the blocks before contract is deployed
-                // TODO fix this in the future
+                // FIXME: events have decoding error in the blocks before contract is deployed
                 Error::EventDecodingError(e.to_string())
             }
             _ => Error::ContractError(e.to_string()),

--- a/crates/topos-sequencer-subnet-client/src/subnet_contract.rs
+++ b/crates/topos-sequencer-subnet-client/src/subnet_contract.rs
@@ -26,10 +26,11 @@ pub(crate) async fn get_block_events(
     contract: &IToposCore<Provider<Ws>>,
     block_number: U64,
 ) -> Result<Vec<crate::SubnetEvent>, Error> {
+    // Parse only event from this particular block
     let events = contract
         .events()
         .from_block(block_number)
-        .to_block(block_number + 1);
+        .to_block(block_number);
     let topos_core_events = events.query_with_meta().await.map_err(|e| {
         match e {
             ContractError::DecodingError(e) => {

--- a/crates/topos-sequencer-subnet-runtime/src/proxy.rs
+++ b/crates/topos-sequencer-subnet-runtime/src/proxy.rs
@@ -28,6 +28,7 @@ pub enum SubnetRuntimeProxyEvent {
     /// New certificate is generated
     NewCertificate {
         cert: Box<Certificate>,
+        block_number: u64,
         ctx: Context,
     },
     /// New set of authorities in charge of the threshold signature
@@ -102,9 +103,13 @@ impl SubnetRuntimeProxy {
             let runtime_proxy = runtime_proxy.clone();
             let subnet_contract_address = subnet_contract_address.clone();
             tokio::spawn(async move {
+                let mut latest_acquired_subnet_block_number = 0;
+
                 {
                     // To start producing certificates, we need to know latest delivered or pending certificate id from TCE
-                    // It could be also genesis certificate (also retrievable from TCE)
+                    // It could be also genesis certificate (also retrievable from TCE). As currently subnet registration is
+                    // not yet implemented on topos subnet, if TCE returns empty certificate history we start getting
+                    // blocks and producing certificates from block 0 (genesis) of the subnet
                     // Lock certification component and wait until we acquire first certificate id for this network
                     let mut certification = certification.lock().await;
                     if certification.last_certificate_id.is_none() {
@@ -117,8 +122,12 @@ impl SubnetRuntimeProxy {
                                     certificate_and_position
                                 );
                                 let cert_id = certificate_and_position.map(|(id, _position)| id);
+                                let position = certificate_and_position
+                                    .map(|(_id, position)| position)
+                                    .unwrap_or_default();
                                 // Certificate generation is now ready to run
                                 certification.last_certificate_id = cert_id;
+                                latest_acquired_subnet_block_number = position;
                             }
                             Err(e) => {
                                 panic!("Failed to get source head certificate, unable to proceed with certificate generation: {e}")
@@ -142,51 +151,88 @@ impl SubnetRuntimeProxy {
                         }
                     }
                 };
-
-                let mut interval = time::interval(SUBNET_BLOCK_TIME);
-
                 let mut subnet_listener = subnet_listener.expect("subnet listener");
 
+                // Sync missing blocks
+                loop {
+                    let current_subnet_block_number: Option<u64> = loop {
+                        tokio::select! {
+                            block_number = subnet_listener.get_subnet_block_number() => {
+                                match block_number {
+                                    Ok(block_number) => {
+                                        break Some(block_number);
+                                    }
+                                    Err(e) => {
+                                        error!("Failed to get subnet block number: {:?}", e);
+                                        break None;
+                                    }
+                                }
+                            }
+                            _ = block_task_shutdown.recv() => {
+                                break None;
+                            }
+                        }
+                    };
+                    let current_subnet_block_number = current_subnet_block_number
+                        .expect("need valid subnet block number to start syncing");
+
+                    if latest_acquired_subnet_block_number == current_subnet_block_number {
+                        info!(
+                            "Finished synchronization of blocks, latest block received is {}",
+                            latest_acquired_subnet_block_number
+                        );
+                        break;
+                    }
+
+                    info!(
+                        "Latest retrieved subnet block is {}, current subnet block is {}",
+                        latest_acquired_subnet_block_number, current_subnet_block_number
+                    );
+                    // Sync historical blocks
+                    while latest_acquired_subnet_block_number < current_subnet_block_number {
+                        let next_block_number = latest_acquired_subnet_block_number + 1;
+                        info!("Retrieving historical block {}", next_block_number);
+                        if let Err(e) = SubnetRuntimeProxy::process_next_block(
+                            runtime_proxy.clone(),
+                            &mut subnet_listener,
+                            certification.clone(),
+                            next_block_number,
+                        )
+                        .await
+                        {
+                            panic!("Unable to perform subnet block sync: {}, closing", e);
+                        } else {
+                            latest_acquired_subnet_block_number = next_block_number;
+                        }
+
+                        // Give it a little rest for other threads to do their job
+                        tokio::time::sleep(Duration::from_millis(20)).await;
+                    }
+                }
+
+                // Go to standard mode of listening for new blocks
+                let mut interval = time::interval(SUBNET_BLOCK_TIME);
                 let shutdowned: Option<oneshot::Sender<()>> = loop {
                     tokio::select! {
                         _ = interval.tick() => {
-
-                            match subnet_listener
-                                .get_next_finalized_block()
-                                .await
-                            {
-                                Ok(block_info) => {
-                                    let block_number = block_info.number;
-                                    info!("Successfully fetched the finalized block {block_number} from the subnet runtime");
-
-                                    let mut certification = certification.lock().await;
-
-                                    // Update certificate block history
-                                    certification.append_blocks(vec![block_info]);
-
-                                    let new_certificates = match certification.generate_certificates().await {
-                                        Ok(certificates) => certificates,
-                                        Err(e) => {
-                                            error!("Unable to generate certificates: {e}");
-                                            break None;
-                                        }
-                                    };
-
-                                    debug!("Generated new certificates {new_certificates:?}");
-
-                                    for cert in new_certificates {
-                                        Self::send_new_certificate(runtime_proxy.clone(), cert).await
+                            let next_block_number = latest_acquired_subnet_block_number + 1;
+                            if let Err(e) = SubnetRuntimeProxy::process_next_block(
+                                runtime_proxy.clone(),
+                                &mut subnet_listener,
+                                certification.clone(),
+                                next_block_number
+                            ).await {
+                                match e {
+                                    Error::SubnetError { source: topos_sequencer_subnet_client::Error::BlockNotAvailable(_) } => {
+                                        continue;
+                                    }
+                                    _ => {
+                                        error!("Failed to process next block: {}", e);
+                                        break None;
                                     }
                                 }
-                                Err(topos_sequencer_subnet_client::Error::BlockNotAvailable(block_number)) => {
-                                    error!("New block {block_number} not yet available, trying again soon");
-                                }
-                                Err(e) => {
-                                    // TODO: Determine if task should end on some type of error
-                                    error!("Failed to fetch the new finalized block: {e}");
-                                    break None;
-                                }
                             }
+                            latest_acquired_subnet_block_number = next_block_number;
                         },
                         shutdown = block_task_shutdown.recv() => {
                             break shutdown;
@@ -246,11 +292,58 @@ impl SubnetRuntimeProxy {
         Ok(runtime_proxy)
     }
 
+    async fn process_next_block(
+        subnet_runtime_proxy: Arc<Mutex<SubnetRuntimeProxy>>,
+        subnet_listener: &mut SubnetClientListener,
+        certification: Arc<Mutex<Certification>>,
+        next_block: u64,
+    ) -> Result<(), Error> {
+        match subnet_listener.get_finalized_block(next_block).await {
+            Ok(block_info) => {
+                let block_number = block_info.number;
+                info!("Successfully fetched the finalized block {block_number} from the subnet runtime");
+
+                let mut certification = certification.lock().await;
+
+                // Update certificate block history
+                certification.append_blocks(vec![block_info]);
+
+                let new_certificates = match certification.generate_certificates().await {
+                    Ok(certificates) => certificates,
+                    Err(e) => {
+                        error!("Unable to generate certificates: {e}");
+                        return Err(e);
+                    }
+                };
+
+                debug!("Generated new certificates {new_certificates:?}");
+
+                for cert in new_certificates {
+                    Self::send_new_certificate(subnet_runtime_proxy.clone(), cert, next_block).await
+                }
+                info!("Block {} processed", next_block);
+                Ok(())
+            }
+            Err(topos_sequencer_subnet_client::Error::BlockNotAvailable(block_number)) => {
+                error!("New block {block_number} not yet available, trying again soon");
+                Err(Error::SubnetError {
+                    source: topos_sequencer_subnet_client::Error::BlockNotAvailable(block_number),
+                })
+            }
+            Err(e) => {
+                // TODO: Determine if task should end on some type of error
+                error!("Failed to fetch the new finalized block: {e}");
+                Err(Error::SubnetError { source: e })
+            }
+        }
+    }
+
     /// Dispatch newly generated certificate to TCE client
     #[instrument(name = "NewCertificate", fields(certification = field::Empty, source_subnet_id = field::Empty, certificate_id = field::Empty))]
     async fn send_new_certificate(
         subnet_runtime_proxy: Arc<Mutex<SubnetRuntimeProxy>>,
         cert: Certificate,
+        block_number: u64,
     ) {
         let mut runtime_proxy = subnet_runtime_proxy.lock().await;
         Span::current().record("certificate_id", cert.id.to_string());
@@ -259,6 +352,7 @@ impl SubnetRuntimeProxy {
         runtime_proxy
             .send_out_event(SubnetRuntimeProxyEvent::NewCertificate {
                 cert: Box::new(cert),
+                block_number,
                 ctx: Span::current().context(),
             })
             .with_current_context()

--- a/crates/topos-sequencer-subnet-runtime/src/proxy.rs
+++ b/crates/topos-sequencer-subnet-runtime/src/proxy.rs
@@ -107,9 +107,6 @@ impl SubnetRuntimeProxy {
 
                 {
                     // To start producing certificates, we need to know latest delivered or pending certificate id from TCE
-                    // It could be also genesis certificate (also retrievable from TCE). As currently subnet registration is
-                    // not yet implemented on topos subnet, if TCE returns empty certificate history we start getting
-                    // blocks and producing certificates from block 0 (genesis) of the subnet
                     // Lock certification component and wait until we acquire first certificate id for this network
                     let mut certification = certification.lock().await;
                     if certification.last_certificate_id.is_none() {

--- a/crates/topos-sequencer-subnet-runtime/tests/subnet_contract.rs
+++ b/crates/topos-sequencer-subnet-runtime/tests/subnet_contract.rs
@@ -458,7 +458,7 @@ async fn test_subnet_node_contract_deployment(
     Ok(())
 }
 
-// /// Test subnet client RPC connection to subnet
+// Test subnet client RPC connection to subnet
 #[rstest]
 #[test(tokio::test)]
 #[serial]
@@ -482,7 +482,7 @@ async fn test_subnet_node_get_block_info(
                     block_info.number
                 );
                 // Blocks must have been mined while we deployed contracts
-                assert!(block_info.number > 5);
+                assert!(block_info.number == 6);
             }
             Err(e) => {
                 panic!("Error getting next finalized block: {e}");

--- a/crates/topos-sequencer-subnet-runtime/tests/subnet_contract.rs
+++ b/crates/topos-sequencer-subnet-runtime/tests/subnet_contract.rs
@@ -475,7 +475,7 @@ async fn test_subnet_node_get_block_info(
     )
     .await
     {
-        Ok(mut subnet_client) => match subnet_client.get_next_finalized_block().await {
+        Ok(mut subnet_client) => match subnet_client.get_finalized_block(6).await {
             Ok(block_info) => {
                 info!(
                     "Block info successfully retrieved for block {}",
@@ -883,7 +883,12 @@ async fn test_subnet_send_token_processing(
     info!("Waiting for certificate with send token transaction...");
     let assertion = async move {
         while let Ok(event) = runtime_proxy_worker.next_event().await {
-            if let SubnetRuntimeProxyEvent::NewCertificate { cert, ctx: _ } = event {
+            if let SubnetRuntimeProxyEvent::NewCertificate {
+                cert,
+                block_number: _,
+                ctx: _,
+            } = event
+            {
                 info!(
                     "New certificate event received, cert id: {} target subnets: {:?}",
                     cert.id, cert.target_subnets

--- a/crates/topos-sequencer/src/app_context.rs
+++ b/crates/topos-sequencer/src/app_context.rs
@@ -74,7 +74,11 @@ impl AppContext {
     async fn on_subnet_runtime_proxy_event(&mut self, evt: SubnetRuntimeProxyEvent) {
         debug!("on_subnet_runtime_proxy_event : {:?}", &evt);
         match evt {
-            SubnetRuntimeProxyEvent::NewCertificate { cert, ctx } => {
+            SubnetRuntimeProxyEvent::NewCertificate {
+                cert,
+                block_number: _,
+                ctx,
+            } => {
                 let span = info_span!("Sequencer app context");
                 span.set_parent(ctx);
                 if let Err(e) = self


### PR DESCRIPTION
# Description

Sequencer now takes the position of last delivered certificate or position + pending certificate index.
It syncs fast from that block to the current subnet block height, then continues listening for new blocks every 2 seconds.

Fixes TP-686


## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
