### PR TITLE
fix: fixing gossip registry metric setup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,9 @@ members = [
     "crates/*"
 ]
 
+[profile.release]
+strip = true
+
 [workspace.dependencies]
 topos-core = { path = "./crates/topos-core", default-features = false }
 topos-crypto = { path = "./crates/topos-crypto", default-features = false }

--- a/crates/topos-p2p/src/behaviour/gossip.rs
+++ b/crates/topos-p2p/src/behaviour/gossip.rs
@@ -63,7 +63,7 @@ impl Behaviour {
         Ok(())
     }
 
-    pub fn new(peer_key: Keypair) -> Self {
+    pub async fn new(peer_key: Keypair) -> Self {
         let batch_size = env::var("TOPOS_GOSSIP_BATCH_SIZE")
             .map(|v| v.parse::<usize>())
             .unwrap_or(Ok(10))
@@ -78,8 +78,8 @@ impl Behaviour {
             MessageAuthenticity::Signed(peer_key),
             gossipsub,
             constant::METRIC_REGISTRY
-                .try_lock()
-                .expect("Failed to lock metric registry during gossipsub creation")
+                .lock()
+                .await
                 .sub_registry_with_prefix("libp2p_gossipsub"),
             Default::default(),
         )

--- a/crates/topos-p2p/src/constant.rs
+++ b/crates/topos-p2p/src/constant.rs
@@ -6,6 +6,8 @@ use tokio::sync::Mutex;
 
 lazy_static! {
     /// Metric Registry used to register all the metrics from libp2p::gossipsub
+    // NOTE: During tests, if multiple instances are started, they will all point to the same
+    // registry.
     pub static ref METRIC_REGISTRY: Mutex<Registry> = Mutex::new(<Registry>::with_prefix("topos"));
     pub static ref EVENT_STREAM_BUFFER: usize = env::var("TCE_EVENT_STREAM_BUFFER")
         .ok()

--- a/crates/topos-p2p/src/network.rs
+++ b/crates/topos-p2p/src/network.rs
@@ -127,7 +127,7 @@ impl<'a> NetworkBuilder<'a> {
         let (command_sender, command_receiver) = mpsc::channel(*COMMAND_STREAM_BUFFER_SIZE);
         let (event_sender, event_receiver) = mpsc::channel(*EVENT_STREAM_BUFFER);
 
-        let gossipsub = gossip::Behaviour::new(peer_key.clone());
+        let gossipsub = gossip::Behaviour::new(peer_key.clone()).await;
         let behaviour = Behaviour {
             gossipsub,
             peer_info: PeerInfoBehaviour::new(PEER_INFO_PROTOCOL, &peer_key),

--- a/crates/topos/Cargo.toml
+++ b/crates/topos/Cargo.toml
@@ -73,6 +73,3 @@ network = ["topos-certificate-spammer"]
 node = ["tce", "sequencer"]
 setup = []
 subnet = []
-
-[profile.release]
-strip = true


### PR DESCRIPTION
# Description

This PR is fixing a regression introduced during the benchmarks phase leading to some test failing due to concurrency on the `Gossipsub` metrics system.

The option was to make the `build` method of `gossip` behavior `async` or to optionally disable metrics on gossip.

The current option is to move to `async`, if we add or need to test metrics system we will have to rework this part.


## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x]  I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
