### PR TITLE
feat: enable https for subnet endpoint

### DIFF
--- a/crates/topos-sequencer-subnet-runtime/src/lib.rs
+++ b/crates/topos-sequencer-subnet-runtime/src/lib.rs
@@ -160,6 +160,8 @@ impl SubnetRuntimeProxyWorker {
     }
 }
 
+/// From the user provided subnet node endpoint (could be ip:port, http://ip:port, https://ip:port)
+/// derive http and ws endpoints that will be used to communicate with the subnet
 pub fn derive_endpoints(endpoint: &str) -> Result<(String, String), Error> {
     let http_endpoint: String;
     let ws_endpoint: String;
@@ -179,6 +181,32 @@ pub fn derive_endpoints(endpoint: &str) -> Result<(String, String), Error> {
         ws_endpoint = format!("ws://{}/ws", endpoint);
     }
     Ok((http_endpoint, ws_endpoint))
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_derive_endpoints() {
+        use super::derive_endpoints;
+        let (http_endpoint, ws_endpoint) = derive_endpoints("10.10.10.13:321").unwrap();
+        assert_eq!(
+            (http_endpoint.as_str(), ws_endpoint.as_str()),
+            ("http://10.10.10.13:321", "ws://10.10.10.13:321/ws")
+        );
+        let (http_endpoint, ws_endpoint) = derive_endpoints("http://www.example.com").unwrap();
+        assert_eq!(
+            (http_endpoint.as_str(), ws_endpoint.as_str()),
+            ("http://www.example.com", "ws://www.example.com/ws")
+        );
+        let (http_endpoint, ws_endpoint) = derive_endpoints("https://www.example.com:123").unwrap();
+        assert_eq!(
+            (http_endpoint.as_str(), ws_endpoint.as_str()),
+            (
+                "https://www.example.com:123",
+                "wss://www.example.com:123/ws"
+            )
+        );
+    }
 }
 
 pub mod testing {

--- a/crates/topos-sequencer-subnet-runtime/src/lib.rs
+++ b/crates/topos-sequencer-subnet-runtime/src/lib.rs
@@ -164,16 +164,16 @@ pub fn derive_endpoints(endpoint: &str) -> Result<(String, String), Error> {
     let http_endpoint: String;
     let ws_endpoint: String;
 
-    if endpoint.starts_with("http") {
-        // Use http endpoint as it is
-        // Derive ws endpoint
-        http_endpoint = endpoint.to_string();
-        ws_endpoint = http_endpoint.replace("http", "ws") + "/ws";
-    } else if endpoint.starts_with("https") {
+    if endpoint.starts_with("https") {
         // Use https endpoint as it is
         // Derive wss endpoint
         http_endpoint = endpoint.to_string();
         ws_endpoint = http_endpoint.replace("https", "wss") + "/ws";
+    } else if endpoint.starts_with("http") {
+        // Use http endpoint as it is
+        // Derive ws endpoint
+        http_endpoint = endpoint.to_string();
+        ws_endpoint = http_endpoint.replace("http", "ws") + "/ws";
     } else {
         http_endpoint = format!("http://{}", endpoint);
         ws_endpoint = format!("ws://{}/ws", endpoint);

--- a/crates/topos-sequencer-subnet-runtime/src/lib.rs
+++ b/crates/topos-sequencer-subnet-runtime/src/lib.rs
@@ -183,6 +183,16 @@ pub fn derive_endpoints(endpoint: &str) -> Result<(String, String), Error> {
     Ok((http_endpoint, ws_endpoint))
 }
 
+pub mod testing {
+    use super::*;
+
+    pub fn get_runtime(
+        runtime_proxy_worker: &SubnetRuntimeProxyWorker,
+    ) -> Arc<Mutex<SubnetRuntimeProxy>> {
+        runtime_proxy_worker.runtime_proxy.clone()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     #[test]
@@ -206,15 +216,5 @@ mod tests {
                 "wss://www.example.com:123/ws"
             )
         );
-    }
-}
-
-pub mod testing {
-    use super::*;
-
-    pub fn get_runtime(
-        runtime_proxy_worker: &SubnetRuntimeProxyWorker,
-    ) -> Arc<Mutex<SubnetRuntimeProxy>> {
-        runtime_proxy_worker.runtime_proxy.clone()
     }
 }

--- a/crates/topos-sequencer-subnet-runtime/src/lib.rs
+++ b/crates/topos-sequencer-subnet-runtime/src/lib.rs
@@ -71,7 +71,7 @@ pub enum Error {
     #[error("Unable to send command: {0}")]
     CommandEvalChannelError(String),
 
-    #[error("Invalid endpooint: {0}")]
+    #[error("Invalid endpoint: {0}")]
     InvalidEndpoint(String),
 }
 

--- a/crates/topos-sequencer-subnet-runtime/src/proxy.rs
+++ b/crates/topos-sequencer-subnet-runtime/src/proxy.rs
@@ -67,12 +67,12 @@ impl SubnetRuntimeProxy {
         signing_key: Vec<u8>,
     ) -> Result<Arc<Mutex<SubnetRuntimeProxy>>, crate::Error> {
         info!(
-            "Spawning new runtime proxy, endpoint: {} ethereum contract address: {}, ",
-            &config.endpoint, &config.subnet_contract_address
+            "Spawning new runtime proxy, http endpoint: {}, ws endpoint {} ethereum contract address: {}, ",
+            &config.http_endpoint, &config.ws_endpoint, &config.subnet_contract_address
         );
         let (command_sender, mut command_rcv) = mpsc::channel::<SubnetRuntimeProxyCommand>(256);
-        let ws_runtime_endpoint = format!("ws://{}/ws", &config.endpoint);
-        let http_runtime_endpoint = format!("http://{}", &config.endpoint);
+        let ws_runtime_endpoint = config.ws_endpoint.clone();
+        let http_runtime_endpoint = config.http_endpoint.clone();
         let subnet_contract_address = Arc::new(config.subnet_contract_address.clone());
         let (command_task_shutdown_channel, mut command_task_shutdown) =
             mpsc::channel::<oneshot::Sender<()>>(1);
@@ -503,10 +503,10 @@ impl SubnetRuntimeProxy {
 
     pub async fn get_checkpoints(&self) -> Result<Vec<TargetStreamPosition>, Error> {
         info!("Connecting to subnet to query for checkpoints...");
-        let http_runtime_endpoint = format!("http://{}", &self.config.endpoint);
+        let http_runtime_endpoint = self.config.http_endpoint.as_ref();
         // Create subnet client
         let subnet_client = match topos_sequencer_subnet_client::connect_to_subnet_with_retry(
-            http_runtime_endpoint.as_ref(),
+            http_runtime_endpoint,
             None, // We do not need actual key here as we are just reading state
             self.config.subnet_contract_address.as_str(),
         )
@@ -515,7 +515,7 @@ impl SubnetRuntimeProxy {
             Ok(subnet_client) => {
                 info!(
                     "Connected to subnet node to acquire checkpoints {}",
-                    &http_runtime_endpoint
+                    http_runtime_endpoint
                 );
                 subnet_client
             }
@@ -540,12 +540,14 @@ impl SubnetRuntimeProxy {
         }
     }
 
-    pub async fn get_subnet_id(endpoint: &str, contract_address: &str) -> Result<SubnetId, Error> {
+    pub async fn get_subnet_id(
+        http_endpoint: &str,
+        contract_address: &str,
+    ) -> Result<SubnetId, Error> {
         info!("Connecting to subnet to query for subnet id...");
-        let http_runtime_endpoint = format!("http://{endpoint}");
         // Create subnet client
         let subnet_client = match topos_sequencer_subnet_client::connect_to_subnet_with_retry(
-            http_runtime_endpoint.as_ref(),
+            http_endpoint,
             None, // We do not need actual key here as we are just reading state
             contract_address,
         )
@@ -554,7 +556,7 @@ impl SubnetRuntimeProxy {
             Ok(subnet_client) => {
                 info!(
                     "Connected to subnet node to acquire subnet id {}",
-                    &http_runtime_endpoint
+                    http_endpoint
                 );
                 subnet_client
             }

--- a/crates/topos-sequencer-subnet-runtime/src/proxy.rs
+++ b/crates/topos-sequencer-subnet-runtime/src/proxy.rs
@@ -540,6 +540,8 @@ impl SubnetRuntimeProxy {
         }
     }
 
+    /// Get the particular subnet id (identifying subnet in the topos protocol)
+    /// from the subnet node smart contract
     pub async fn get_subnet_id(
         http_endpoint: &str,
         contract_address: &str,

--- a/crates/topos-sequencer-subnet-runtime/tests/subnet_contract.rs
+++ b/crates/topos-sequencer-subnet-runtime/tests/subnet_contract.rs
@@ -184,7 +184,7 @@ impl Context {
     }
 
     pub fn jsonrpc(&self) -> String {
-        format!("127.0.0.1:{}", self.port)
+        format!("http://127.0.0.1:{}", self.port)
     }
 
     pub fn jsonrpc_ws(&self) -> String {
@@ -507,7 +507,8 @@ async fn test_create_runtime() -> Result<(), Box<dyn std::error::Error>> {
     let runtime_proxy_worker = SubnetRuntimeProxyWorker::new(
         SubnetRuntimeProxyConfig {
             subnet_id: SOURCE_SUBNET_ID_1,
-            endpoint: format!("localhost:{SUBNET_RPC_PORT}"),
+            http_endpoint: format!("http://localhost:{SUBNET_RPC_PORT}"),
+            ws_endpoint: format!("ws://localhost:{SUBNET_RPC_PORT}/ws"),
             subnet_contract_address: "0x0000000000000000000000000000000000000000".to_string(),
             verifier: 0,
             source_head_certificate_id: None,
@@ -538,7 +539,8 @@ async fn test_subnet_certificate_push_call(
     let runtime_proxy_worker = SubnetRuntimeProxyWorker::new(
         SubnetRuntimeProxyConfig {
             subnet_id: SOURCE_SUBNET_ID_1,
-            endpoint: context.jsonrpc(),
+            http_endpoint: context.jsonrpc(),
+            ws_endpoint: context.jsonrpc_ws(),
             subnet_contract_address: subnet_smart_contract_address.clone(),
             verifier: 0,
             source_head_certificate_id: None,
@@ -652,7 +654,7 @@ async fn test_subnet_certificate_get_checkpoints_call(
     let context = context_running_subnet_node.await;
     let subnet_smart_contract_address =
         "0x".to_string() + &hex::encode(context.i_topos_core.address());
-    let subnet_jsonrpc_endpoint = "http://".to_string() + &context.jsonrpc();
+    let subnet_jsonrpc_endpoint = context.jsonrpc();
 
     // Get checkpoints when contract is empty
     let subnet_client = topos_sequencer_subnet_client::SubnetClient::new(
@@ -770,7 +772,7 @@ async fn test_subnet_id_call(
     let context = context_running_subnet_node.await;
     let subnet_smart_contract_address =
         "0x".to_string() + &hex::encode(context.i_topos_core.address());
-    let subnet_jsonrpc_endpoint = "http://".to_string() + &context.jsonrpc();
+    let subnet_jsonrpc_endpoint = context.jsonrpc();
 
     // Create subnet client
     let subnet_client = topos_sequencer_subnet_client::SubnetClient::new(
@@ -816,7 +818,7 @@ async fn test_subnet_send_token_processing(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let context = context_running_subnet_node.await;
     let test_private_key = hex::decode(TEST_SECRET_ETHEREUM_KEY).unwrap();
-    let subnet_jsonrpc_endpoint = "http://".to_string() + &context.jsonrpc();
+    let subnet_jsonrpc_endpoint = context.jsonrpc();
     let subnet_smart_contract_address =
         "0x".to_string() + &hex::encode(context.i_topos_core.address());
 
@@ -825,7 +827,8 @@ async fn test_subnet_send_token_processing(
     let mut runtime_proxy_worker = SubnetRuntimeProxyWorker::new(
         SubnetRuntimeProxyConfig {
             subnet_id: SOURCE_SUBNET_ID_1,
-            endpoint: context.jsonrpc(),
+            http_endpoint: context.jsonrpc(),
+            ws_endpoint: context.jsonrpc_ws(),
             subnet_contract_address: subnet_smart_contract_address.clone(),
             verifier: 0,
             source_head_certificate_id: None,

--- a/crates/topos-sequencer/src/lib.rs
+++ b/crates/topos-sequencer/src/lib.rs
@@ -73,7 +73,6 @@ pub async fn launch(
         }
     };
 
-    // TODO Here determine if websocket endpoint is provided or should be derived from http endpoint
     let (http_endpoint, ws_endpoint) =
         topos_sequencer_subnet_runtime::derive_endpoints(&config.subnet_jsonrpc_endpoint)?;
 

--- a/crates/topos-sequencer/src/lib.rs
+++ b/crates/topos-sequencer/src/lib.rs
@@ -53,7 +53,7 @@ pub async fn launch(
                 .map_err(|e| {
                     Box::new(std::io::Error::new(
                         InvalidInput,
-                        format!("Invalid subnet endpoint: {}", e.to_string()),
+                        format!("Invalid subnet endpoint: {e}"),
                     ))
                 })?
                 .0;

--- a/crates/topos/src/config/sequencer.rs
+++ b/crates/topos/src/config/sequencer.rs
@@ -15,7 +15,7 @@ pub struct SequencerConfig {
     pub subnet_id: Option<String>,
 
     /// JSON-RPC endpoint of the Edge node, websocket and http support expected
-    /// If endpoint address starts with `https`, ssl will be used with http/websocket
+    /// If the endpoint address starts with `https`, ssl will be used with http/websocket
     #[serde(default = "default_subnet_jsonrpc_endpoint")]
     pub subnet_jsonrpc_endpoint: String,
 

--- a/crates/topos/src/config/sequencer.rs
+++ b/crates/topos/src/config/sequencer.rs
@@ -15,6 +15,7 @@ pub struct SequencerConfig {
     pub subnet_id: Option<String>,
 
     /// JSON-RPC endpoint of the Edge node, websocket and http support expected
+    /// If endpoint address starts with `https`, ssl will be used with http/websocket
     #[serde(default = "default_subnet_jsonrpc_endpoint")]
     pub subnet_jsonrpc_endpoint: String,
 


### PR DESCRIPTION
# Description

Added https support for sequencer subnet client.

Fixes TP-699

## Additions and Changes

Now, `--subnet-jsonrpc-endpoint` argument could be:

- `127.0.0.1:10002` meaning sequencer will use `http://127.0.0.1:10002` and `ws://127.0.0.1:10002/ws` for jsonrpc subnet endpoint
- `http://mydomain.com:1000` meaning sequencer will use `http://mydomain.com:1000` and `ws://mydomain.com:1000/ws` for jsonrpc subnet endpoint
- `https://mydomain.com:300` meaning sequencer will use `https://mydomain.com:300` and `wss://mydomain.com:300/ws` for jsonrpc subnet endpoint



## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
