### PR TITLE
ci: run docker workflow on release

### DIFF
--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -5,6 +5,8 @@ on:
     branches: [main, debug/**]
   pull_request:
     branches: [main]
+  release:
+    types: [created]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -30,6 +32,7 @@ jobs:
   docker_e2e:
     runs-on: ubuntu-latest-16-core
     needs: docker
+    if: ${{ github.event_name == 'pull_request' }}
     env:
       EXPECTED_IMAGE_NAME: ghcr.io/${{ github.repository }}:main
     steps:
@@ -81,6 +84,7 @@ jobs:
   frontend-erc20-e2e:
     runs-on: ubuntu-latest
     needs: docker
+    if: ${{ github.event_name == 'pull_request' }}
     steps:
       - name: Set environment
         run: |

--- a/.github/workflows/docker_utils.yml
+++ b/.github/workflows/docker_utils.yml
@@ -80,8 +80,9 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=ref,event=branch,suffix=${{ inputs.features != env.DEFAULT_FEATURES && format('-{0}', inputs.features) || '' }}
-            type=ref,event=tag,suffix=${{ inputs.features != env.DEFAULT_FEATURES && format('-{0}', inputs.features) || '' }}
             type=ref,event=pr,suffix=${{ inputs.features != env.DEFAULT_FEATURES && format('-{0}', inputs.features) || '' }}
+            type=semver,suffix=${{ inputs.features != env.DEFAULT_FEATURES && format('-{0}', inputs.features) || '' }},pattern={{version}}
+            type=semver,suffix=${{ inputs.features != env.DEFAULT_FEATURES && format('-{0}', inputs.features) || '' }},pattern={{major}}.{{minor}}
 
       - name: Push to GitHub Container Registry
         uses: docker/build-push-action@v3


### PR DESCRIPTION
# Description

This PR adds a CI trigger for the docker build-push workflow so that we get docker images for releases.

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
