### PR TITLE
fix: switch to safe grpc conversion for cert

### DIFF
--- a/crates/topos-api/src/grpc/conversions/shared/v1/subnet.rs
+++ b/crates/topos-api/src/grpc/conversions/shared/v1/subnet.rs
@@ -17,6 +17,21 @@ impl std::fmt::Display for SubnetId {
 pub enum Error {
     #[error("Unable to parse subnetId ({0})")]
     ValidationError(SubnetId),
+
+    #[error("Unable to parse UCI field ({0}))")]
+    UCI(#[from] topos_uci::Error),
+
+    #[error("Missing mandatory field: {0}")]
+    MissingField(&'static str),
+
+    #[error("Invalid or missing state_root")]
+    InvalidStateRoot,
+
+    #[error("Invalid or missing tx_root_hash")]
+    InvalidTxRootHash,
+
+    #[error("Invalid or missing receipts_root_hash")]
+    InvalidReceiptsRootHash,
 }
 
 impl From<[u8; SUBNET_ID_LENGTH]> for SubnetId {

--- a/crates/topos-api/src/grpc/conversions/uci/v1/uci.rs
+++ b/crates/topos-api/src/grpc/conversions/uci/v1/uci.rs
@@ -11,30 +11,28 @@ impl TryFrom<proto_v1::Certificate> for topos_uci::Certificate {
         Ok(topos_uci::Certificate {
             prev_id: certificate
                 .prev_id
-                .expect("valid previous certificate id")
+                .ok_or(Error::MissingField("certificate.prev_id"))?
                 .value
                 .as_slice()
-                .try_into()
-                .expect("valid previous certificate id with correct length"),
+                .try_into()?,
             source_subnet_id: certificate
                 .source_subnet_id
-                .expect("valid source subnet id")
+                .ok_or(Error::MissingField("certificate.source_subnet_id"))?
                 .value
                 .as_slice()
-                .try_into()
-                .expect("valid source subnet id with correct length"),
+                .try_into()?,
             state_root: certificate
                 .state_root
                 .try_into()
-                .expect("valid state root with correct length"),
+                .map_err(|_| Error::InvalidStateRoot)?,
             tx_root_hash: certificate
                 .tx_root_hash
                 .try_into()
-                .expect("valid transaction root hash with correct length"),
+                .map_err(|_| Error::InvalidTxRootHash)?,
             receipts_root_hash: certificate
                 .receipts_root_hash
                 .try_into()
-                .expect("valid receipts root hash with correct length"),
+                .map_err(|_| Error::InvalidReceiptsRootHash)?,
             target_subnets: certificate
                 .target_subnets
                 .into_iter()
@@ -43,11 +41,10 @@ impl TryFrom<proto_v1::Certificate> for topos_uci::Certificate {
             verifier: certificate.verifier,
             id: certificate
                 .id
-                .expect("valid certificate id")
+                .ok_or(Error::MissingField("certificate.id"))?
                 .value
                 .as_slice()
-                .try_into()
-                .expect("valid certificate id with correct length"),
+                .try_into()?,
             proof: certificate.proof.expect("valid proof").value,
             signature: certificate.signature.expect("valid frost signature").value,
         })


### PR DESCRIPTION
# Description

In order to avoid panicking when malformed certificates are pushed or failure during parsing.

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
