### PR TITLE
fix: submit certificate to tce using backoff algorithm in case of error

### DIFF
--- a/crates/topos-tce-broadcast/src/lib.rs
+++ b/crates/topos-tce-broadcast/src/lib.rs
@@ -135,7 +135,7 @@ impl ReliableBroadcastClient {
             command_receiver,
             event_sender,
             double_echo_shutdown_receiver,
-            validator_store.clone(),
+            validator_store,
             broadcast_sender,
         );
 

--- a/crates/topos-tce-broadcast/src/task_manager_futures/mod.rs
+++ b/crates/topos-tce-broadcast/src/task_manager_futures/mod.rs
@@ -54,6 +54,7 @@ pub struct TaskManager {
 }
 
 impl TaskManager {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         message_receiver: mpsc::Receiver<DoubleEchoCommand>,
         task_completion_sender: mpsc::Sender<(CertificateId, TaskStatus)>,

--- a/crates/topos-tce-proxy/src/client.rs
+++ b/crates/topos-tce-proxy/src/client.rs
@@ -360,7 +360,7 @@ impl TceClientBuilder {
 
                                 let tce_endpoint = tce_endpoint.clone();
                                 let tce_grpc_client = tce_grpc_client.clone();
-                                let context_send = context.clone();
+                                let context_backoff = context.clone();
                                 certificate_to_send.push(async move {
                                     debug!("Submitting certificate {} to the TCE using backoff strategy...", &tce_endpoint);
                                     let cert = cert.clone();
@@ -371,11 +371,11 @@ impl TceClientBuilder {
                                         }.into_request();
 
                                         let mut span_context = topos_telemetry::TonicMetaInjector(request.metadata_mut());
-                                        span_context.inject(&context_send);
+                                        span_context.inject(&context_backoff);
 
                                         tce_grpc_client
                                         .submit_certificate(request)
-                                        .with_current_context()
+                                        .with_context(context_backoff.clone())
                                         .instrument(Span::current())
                                         .await
                                         .map(|_response| {

--- a/crates/topos-tce-proxy/tests/tce_tests.rs
+++ b/crates/topos-tce-proxy/tests/tce_tests.rs
@@ -602,6 +602,11 @@ async fn test_tce_proxy_submit_certificate(
         }
     }
 
+    // Wait for certificates to be submitted
+    tokio::time::sleep(Duration::from_secs(5)).await;
+
+    // TODO: get pending certificates from TCE to make sure they were actually submitted
+
     info!("Shutting down TCE node client");
     context.shutdown().await?;
     Ok(())

--- a/crates/topos-tce-synchronizer/src/checkpoints_collector/tests.rs
+++ b/crates/topos-tce-synchronizer/src/checkpoints_collector/tests.rs
@@ -33,7 +33,7 @@ fn encode() {
         request_id: Some(request_id),
         checkpoint_diff: vec![CheckpointMapFieldEntry {
             key: subnet.to_string(),
-            value: vec![cert.proof_of_delivery.clone().into()],
+            value: vec![cert.proof_of_delivery.into()],
         }],
     };
 


### PR DESCRIPTION
# Description

In case that `topos-tce-proxy` client fails to submit certificate to the TCE, it will retry using backoff algorith.

Fixes TP-719


## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
