### PR TITLE
feat: add start block

### DIFF
--- a/crates/topos-sequencer-subnet-runtime/src/lib.rs
+++ b/crates/topos-sequencer-subnet-runtime/src/lib.rs
@@ -83,6 +83,7 @@ pub struct SubnetRuntimeProxyConfig {
     pub subnet_contract_address: String,
     pub source_head_certificate_id: Option<CertificateId>,
     pub verifier: u32,
+    pub start_block: Option<u64>,
 }
 
 /// Thread safe client to the protocol aggregate

--- a/crates/topos-sequencer-subnet-runtime/src/proxy.rs
+++ b/crates/topos-sequencer-subnet-runtime/src/proxy.rs
@@ -105,9 +105,9 @@ impl SubnetRuntimeProxy {
             let runtime_proxy = runtime_proxy.clone();
             let subnet_contract_address = subnet_contract_address.clone();
             tokio::spawn(async move {
-                // if `start_block` parameter is provided, first block retrieved (genesis certificate)
-                // will be start block. `default_block_sync_start` is hence `start_block`-1
-                // as first retrieved block is latest_acquired_subnet_block_number + 1
+                // If the `start_block` sequencer parameter is provided, first block retrieved from blockchain (for genesis certificate)
+                // will be `start_block`. `default_block_sync_start` is hence `start_block`-1
+                // as first block retrieved from subnet node is `latest_acquired_subnet_block_number` + 1
                 let default_block_sync_start: i128 = config
                     .start_block
                     .map(|block_number| (block_number - 1) as i128)

--- a/crates/topos-sequencer-subnet-runtime/src/proxy.rs
+++ b/crates/topos-sequencer-subnet-runtime/src/proxy.rs
@@ -122,10 +122,10 @@ impl SubnetRuntimeProxy {
                                     "Source head certificate id received {:?}",
                                     certificate_and_position
                                 );
-                                // If tce source head position is provided, continue syncing from it
-                                // If `start_block` sequencer parameter is provided and tce source head is missing,
-                                // we should start syncing from that block instead of genesis
-                                // If both tce source head position and start_block parameter are not provided,
+                                // If tce source head position is provided, continue synchronizing from it
+                                // If the `start_block` sequencer parameter is provided and tce source head is missing,
+                                // we should start synchronizing from that block instead of genesis
+                                // If neither tce source head position nor start_block parameters are provided,
                                 // sync should start form -1, so that first fetched is subnet genesis block
                                 let default_block_sync: i128 =
                                     config.start_block.map(|i| i as i128).unwrap_or(-1);

--- a/crates/topos-sequencer-subnet-runtime/src/proxy.rs
+++ b/crates/topos-sequencer-subnet-runtime/src/proxy.rs
@@ -122,11 +122,17 @@ impl SubnetRuntimeProxy {
                                     "Source head certificate id received {:?}",
                                     certificate_and_position
                                 );
-                                // If the position is not provided, it should start form -1, so that first fetched is subnet genesis block
+                                // If tce source head position is provided, continue syncing from it
+                                // If `start_block` sequencer parameter is provided and tce source head is missing,
+                                // we should start syncing from that block instead of genesis
+                                // If both tce source head position and start_block parameter are not provided,
+                                // sync should start form -1, so that first fetched is subnet genesis block
+                                let default_block_sync: i128 =
+                                    config.start_block.map(|i| i as i128).unwrap_or(-1);
                                 let cert_id = certificate_and_position.map(|(id, _position)| id);
                                 let position: i128 = certificate_and_position
                                     .map(|(_id, position)| position as i128)
-                                    .unwrap_or(-1);
+                                    .unwrap_or(default_block_sync);
                                 // Certificate generation is now ready to run
                                 certification.last_certificate_id = cert_id;
                                 latest_acquired_subnet_block_number = position;

--- a/crates/topos-sequencer-subnet-runtime/src/proxy.rs
+++ b/crates/topos-sequencer-subnet-runtime/src/proxy.rs
@@ -104,7 +104,9 @@ impl SubnetRuntimeProxy {
             let runtime_proxy = runtime_proxy.clone();
             let subnet_contract_address = subnet_contract_address.clone();
             tokio::spawn(async move {
-                let mut latest_acquired_subnet_block_number: i128 = -1;
+                let default_block_sync: i128 =
+                    config.start_block.map(|i| i as i128).unwrap_or(-1);
+                let mut latest_acquired_subnet_block_number: i128 = default_block_sync;
 
                 {
                     // To start producing certificates, we need to know latest delivered or pending certificate id from TCE
@@ -127,8 +129,6 @@ impl SubnetRuntimeProxy {
                                 // we should start synchronizing from that block instead of genesis
                                 // If neither tce source head position nor start_block parameters are provided,
                                 // sync should start form -1, so that first fetched is subnet genesis block
-                                let default_block_sync: i128 =
-                                    config.start_block.map(|i| i as i128).unwrap_or(-1);
                                 let cert_id = certificate_and_position.map(|(id, _position)| id);
                                 let position: i128 = certificate_and_position
                                     .map(|(_id, position)| position as i128)

--- a/crates/topos-sequencer-subnet-runtime/tests/subnet_contract.rs
+++ b/crates/topos-sequencer-subnet-runtime/tests/subnet_contract.rs
@@ -467,6 +467,70 @@ async fn deploy_test_token(
     Ok(i_erc20)
 }
 
+async fn check_received_certificate(
+    mut runtime_proxy_worker: SubnetRuntimeProxyWorker,
+    received_certificates: Arc<Mutex<Vec<(u64, Certificate)>>>,
+    expected_block_numbers: Vec<u64>,
+    expected_blocks: Vec<Block<H256>>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let start_height = *expected_block_numbers.first().unwrap();
+    let end_height = *expected_block_numbers.last().unwrap();
+    while let Ok(event) = runtime_proxy_worker.next_event().await {
+        if let SubnetRuntimeProxyEvent::NewCertificate {
+            cert,
+            block_number,
+            ctx: _,
+        } = event
+        {
+            info!(
+                "New certificate event received, block number: {} cert id: {} target subnets: \
+                 {:?} state root {}",
+                block_number,
+                cert.id,
+                cert.target_subnets,
+                hex::encode(cert.state_root)
+            );
+            let mut received_certificates = received_certificates.lock().await;
+            received_certificates.push((block_number, *cert));
+
+            if received_certificates
+                .iter()
+                .take(end_height as usize + 1)
+                .map(|(height, _cert)| height)
+                .copied()
+                .collect::<Vec<_>>()
+                == expected_block_numbers
+            {
+                info!(
+                    "Received all certificates for blocks from {} to {}",
+                    start_height, end_height
+                );
+                // Check if state root matches for all blocks
+                for expected_height in expected_block_numbers {
+                    let index = (expected_height - start_height) as usize;
+                    let received_certificate = &received_certificates[index].1;
+                    if expected_blocks[index].state_root
+                        != ethers::types::TxHash(received_certificate.state_root)
+                    {
+                        error!(
+                            "State root mismatch, block: {:#?}\n received certificate: {:#?}",
+                            expected_blocks[index], received_certificates[index].1
+                        );
+                        panic!("State root mismatch");
+                    }
+                }
+                info!(
+                    "State root check successfully passed for blocks from {} to {}",
+                    start_height, end_height
+                );
+
+                return Ok::<(), Box<dyn std::error::Error>>(());
+            }
+        }
+    }
+    panic!("Expected event not received");
+}
+
 #[fixture]
 async fn context_running_subnet_node(
     #[default(8545)] port: u32,
@@ -996,11 +1060,12 @@ async fn test_subnet_send_token_processing(
 }
 
 // Test sync of blocks and generating certificates from genesis block
+// and test sync from particular source head received from tce
 #[rstest]
 #[test(tokio::test)]
 #[timeout(std::time::Duration::from_secs(600))]
 #[serial]
-async fn test_sync_from_genesis(
+async fn test_sync_from_genesis_and_particular_source_head(
     #[with(8546)]
     #[future]
     context_running_subnet_node: Context,
@@ -1046,70 +1111,6 @@ async fn test_sync_from_genesis(
     info!("Waiting for the certificates from zero until height {subnet_height}...");
     let received_certificates = Arc::new(Mutex::new(Vec::new()));
 
-    async fn check_received_certificate(
-        mut runtime_proxy_worker: SubnetRuntimeProxyWorker,
-        received_certificates: Arc<Mutex<Vec<(u64, Certificate)>>>,
-        expected_block_numbers: Vec<u64>,
-        expected_blocks: Vec<Block<H256>>,
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        let start_height = *expected_block_numbers.first().unwrap();
-        let end_height = *expected_block_numbers.last().unwrap();
-        while let Ok(event) = runtime_proxy_worker.next_event().await {
-            if let SubnetRuntimeProxyEvent::NewCertificate {
-                cert,
-                block_number,
-                ctx: _,
-            } = event
-            {
-                info!(
-                    "New certificate event received, block number: {} cert id: {} target subnets: \
-                     {:?} state root {}",
-                    block_number,
-                    cert.id,
-                    cert.target_subnets,
-                    hex::encode(cert.state_root)
-                );
-                let mut received_certificates = received_certificates.lock().await;
-                received_certificates.push((block_number, *cert));
-
-                if received_certificates
-                    .iter()
-                    .take(end_height as usize + 1)
-                    .map(|(height, _cert)| height)
-                    .copied()
-                    .collect::<Vec<_>>()
-                    == expected_block_numbers
-                {
-                    info!(
-                        "Received all certificates for blocks from {} to {}",
-                        start_height, end_height
-                    );
-                    // Check if state root matches for all blocks
-                    for expected_height in expected_block_numbers {
-                        let index = (expected_height - start_height) as usize;
-                        let received_certificate = &received_certificates[index].1;
-                        if expected_blocks[index].state_root
-                            != ethers::types::TxHash(received_certificate.state_root)
-                        {
-                            error!(
-                                "State root mismatch, block: {:#?}\n received certificate: {:#?}",
-                                expected_blocks[index], received_certificates[index].1
-                            );
-                            panic!("State root mismatch");
-                        }
-                    }
-                    info!(
-                        "State root check successfully passed for blocks from {} to {}",
-                        start_height, end_height
-                    );
-
-                    return Ok::<(), Box<dyn std::error::Error>>(());
-                }
-            }
-        }
-        panic!("Expected event not received");
-    }
-
     // Test sync from genesis block
     {
         let expected_block_numbers = (0..=subnet_height).collect::<Vec<_>>();
@@ -1147,13 +1148,13 @@ async fn test_sync_from_genesis(
     //---------------------------------------------------------------------
     //
     // Get block height
-    let http_provider_2 = Provider::<Http>::try_from(subnet_jsonrpc_endpoint)?
+    let http_provider = Provider::<Http>::try_from(subnet_jsonrpc_endpoint)?
         .interval(std::time::Duration::from_millis(20u64));
-    let subnet_height_2 = http_provider_2.get_block_number().await?.as_u64();
+    let subnet_height = http_provider.get_block_number().await?.as_u64();
     const SYNC_START_BLOCK_NUMBER: u64 = 11;
 
-    // Create runtime proxy worker 2
-    info!("Creating subnet runtime proxy 2");
+    // Create second runtime proxy worker
+    info!("Creating second subnet runtime proxy worker");
     let runtime_proxy_worker_2 = SubnetRuntimeProxyWorker::new(
         SubnetRuntimeProxyConfig {
             subnet_id: SOURCE_SUBNET_ID_1,
@@ -1187,27 +1188,122 @@ async fn test_sync_from_genesis(
 
     // Test sync from 11 block
     {
-        let expected_block_numbers_2 =
-            (SYNC_START_BLOCK_NUMBER..=subnet_height_2).collect::<Vec<_>>();
-        let mut expected_blocks_2 = Vec::new();
-        for height in &expected_block_numbers_2 {
+        let expected_block_numbers = (SYNC_START_BLOCK_NUMBER..=subnet_height).collect::<Vec<_>>();
+        let mut expected_blocks = Vec::new();
+        for height in &expected_block_numbers {
             match http_provider.get_block(*height).await {
-                Ok(block_info) => expected_blocks_2.push(block_info.expect("valid block")),
+                Ok(block_info) => expected_blocks.push(block_info.expect("valid block")),
                 Err(e) => {
                     panic!("Unable to get block number {}: {}", height, e);
                 }
             }
         }
-        let received_certificates_2 = Arc::new(Mutex::new(Vec::new()));
+        let received_certificates = Arc::new(Mutex::new(Vec::new()));
 
         // Set big timeout to prevent flaky fails. Instead fail/panic early in the test to indicate actual error
         if tokio::time::timeout(
             std::time::Duration::from_secs(60),
             check_received_certificate(
                 runtime_proxy_worker_2,
-                received_certificates_2,
-                expected_block_numbers_2,
-                expected_blocks_2,
+                received_certificates,
+                expected_block_numbers,
+                expected_blocks,
+            ),
+        )
+        .await
+        .is_err()
+        {
+            panic!("Timeout waiting for command");
+        }
+    }
+
+    info!("Shutting down context...");
+
+    context.shutdown().await?;
+    Ok(())
+}
+
+// Test sync of blocks and generating certificates start block parameter
+#[rstest]
+#[test(tokio::test)]
+#[timeout(std::time::Duration::from_secs(600))]
+#[serial]
+async fn test_sync_from_start_block(
+    #[with(8546)]
+    #[future]
+    context_running_subnet_node: Context,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let context = context_running_subnet_node.await;
+    let test_private_key = hex::decode(TEST_SECRET_ETHEREUM_KEY).unwrap();
+    let subnet_jsonrpc_endpoint = context.jsonrpc();
+    let subnet_smart_contract_address =
+        "0x".to_string() + &hex::encode(context.i_topos_core.address());
+
+    // Wait for some time to simulate network history
+    tokio::time::sleep(tokio::time::Duration::from_secs(10)).await;
+
+    // Get block height
+    let http_provider = Provider::<Http>::try_from(subnet_jsonrpc_endpoint.clone())?
+        .interval(std::time::Duration::from_millis(20u64));
+    let subnet_height = http_provider.get_block_number().await?.as_u64();
+
+    // Define start block as current subnet height reduced by 5
+    let start_block: u64 = subnet_height - 5;
+
+    // Create runtime proxy worker
+    info!("Creating subnet runtime proxy");
+    let runtime_proxy_worker = SubnetRuntimeProxyWorker::new(
+        SubnetRuntimeProxyConfig {
+            subnet_id: SOURCE_SUBNET_ID_1,
+            http_endpoint: context.jsonrpc(),
+            ws_endpoint: context.jsonrpc_ws(),
+            subnet_contract_address: subnet_smart_contract_address.clone(),
+            verifier: 0,
+            source_head_certificate_id: None,
+            start_block: Some(start_block),
+        },
+        test_private_key.clone(),
+    )
+    .await?;
+    tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+
+    info!("Manually set source head certificate to 0 as TCE is not available");
+    if let Err(e) = runtime_proxy_worker
+        .set_source_head_certificate_id(None)
+        .await
+    {
+        panic!("Unable to set source head certificate id: {e}");
+    }
+
+    info!(
+        "Syncing from the start block {} to current height {}",
+        start_block, subnet_height
+    );
+
+    let received_certificates = Arc::new(Mutex::new(Vec::new()));
+
+    // Test sync from start block
+    {
+        let expected_block_numbers = (start_block..=subnet_height).collect::<Vec<_>>();
+        let mut expected_blocks = Vec::new();
+        for height in &expected_block_numbers {
+            match http_provider.get_block(*height).await {
+                Ok(block_info) => expected_blocks.push(block_info.expect("valid block")),
+                Err(e) => {
+                    panic!("Unable to get block number {}: {}", height, e);
+                }
+            }
+        }
+        let received_certificates = received_certificates.clone();
+
+        // Set big timeout to prevent flaky fails. Instead fail/panic early in the test to indicate actual error
+        if tokio::time::timeout(
+            std::time::Duration::from_secs(60),
+            check_received_certificate(
+                runtime_proxy_worker,
+                received_certificates,
+                expected_block_numbers,
+                expected_blocks,
             ),
         )
         .await

--- a/crates/topos-sequencer-subnet-runtime/tests/subnet_contract.rs
+++ b/crates/topos-sequencer-subnet-runtime/tests/subnet_contract.rs
@@ -582,6 +582,7 @@ async fn test_create_runtime() -> Result<(), Box<dyn std::error::Error>> {
             subnet_contract_address: "0x0000000000000000000000000000000000000000".to_string(),
             verifier: 0,
             source_head_certificate_id: None,
+            start_block: None,
         },
         test_private_key,
     )
@@ -614,6 +615,7 @@ async fn test_subnet_certificate_push_call(
             subnet_contract_address: subnet_smart_contract_address.clone(),
             verifier: 0,
             source_head_certificate_id: None,
+            start_block: None,
         },
         admin_key.clone(),
     )
@@ -902,6 +904,7 @@ async fn test_subnet_send_token_processing(
             subnet_contract_address: subnet_smart_contract_address.clone(),
             verifier: 0,
             source_head_certificate_id: None,
+            start_block: None,
         },
         test_private_key.clone(),
     )
@@ -1026,6 +1029,7 @@ async fn test_sync_from_genesis(
             subnet_contract_address: subnet_smart_contract_address.clone(),
             verifier: 0,
             source_head_certificate_id: None,
+            start_block: None,
         },
         test_private_key.clone(),
     )
@@ -1158,6 +1162,7 @@ async fn test_sync_from_genesis(
             subnet_contract_address: subnet_smart_contract_address.clone(),
             verifier: 0,
             source_head_certificate_id: None,
+            start_block: None,
         },
         test_private_key.clone(),
     )
@@ -1248,6 +1253,7 @@ async fn test_subnet_multiple_send_token_in_a_block(
             subnet_contract_address: subnet_smart_contract_address.clone(),
             verifier: 0,
             source_head_certificate_id: None,
+            start_block: None,
         },
         test_private_key.clone(),
     )

--- a/crates/topos-sequencer/src/lib.rs
+++ b/crates/topos-sequencer/src/lib.rs
@@ -25,6 +25,7 @@ pub struct SequencerConfiguration {
     pub tce_grpc_endpoint: String,
     pub signing_key: SecretKey,
     pub verifier: u32,
+    pub start_block: Option<u64>,
 }
 
 pub async fn launch(
@@ -85,6 +86,7 @@ pub async fn launch(
             subnet_contract_address: config.subnet_contract_address.clone(),
             source_head_certificate_id: None, // Must be acquired later after TCE proxy is connected
             verifier: config.verifier,
+            start_block: config.start_block,
         },
         config.signing_key.clone(),
     )

--- a/crates/topos/src/components/node/services.rs
+++ b/crates/topos/src/components/node/services.rs
@@ -64,6 +64,7 @@ pub(crate) fn spawn_sequencer_process(
         tce_grpc_endpoint: config.tce_grpc_endpoint,
         signing_key: keys.validator.clone().unwrap(),
         verifier: 0,
+        start_block: config.start_block,
     };
 
     debug!("Sequencer args: {config:?}");

--- a/crates/topos/src/components/sequencer/commands/run.rs
+++ b/crates/topos/src/components/sequencer/commands/run.rs
@@ -49,8 +49,8 @@ pub struct Run {
     #[arg(long, env = "TOPOS_OTLP_SERVICE_NAME")]
     pub otlp_service_name: Option<String>,
 
-    /// Start syncing from particular block number
-    /// Default is to sync from genesis block 0
+    /// Start synchronizing from particular block number
+    /// Default is to sync from genesis block (0)
     #[arg(long, env = "TOPOS_START_BLOCK")]
     pub start_block: Option<u64>,
 }

--- a/crates/topos/src/components/sequencer/commands/run.rs
+++ b/crates/topos/src/components/sequencer/commands/run.rs
@@ -48,6 +48,11 @@ pub struct Run {
     /// If not provided open telemetry will not be used
     #[arg(long, env = "TOPOS_OTLP_SERVICE_NAME")]
     pub otlp_service_name: Option<String>,
+
+    /// Start syncing from particular block number
+    /// Default is to sync from genesis block 0
+    #[arg(long, env = "TOPOS_START_BLOCK")]
+    pub start_block: Option<u64>,
 }
 
 impl Run {}

--- a/crates/topos/src/components/sequencer/mod.rs
+++ b/crates/topos/src/components/sequencer/mod.rs
@@ -26,6 +26,7 @@ pub(crate) async fn handle_command(
                 tce_grpc_endpoint: cmd.base_tce_api_url,
                 signing_key: keys.validator.clone().unwrap(),
                 verifier: cmd.verifier,
+                start_block: cmd.start_block,
             };
 
             // Setup instrumentation if both otlp agent and otlp service name are provided as arguments

--- a/crates/topos/src/config/sequencer.rs
+++ b/crates/topos/src/config/sequencer.rs
@@ -33,8 +33,8 @@ pub struct SequencerConfig {
     /// OTLP service name, not used if not provided
     pub otlp_service_name: Option<String>,
 
-    /// Start syncing from particular block number
-    /// Default is to sync from genesis block 0
+    /// Start synchronizing from particular block number
+    /// Default is to sync from genesis block (0)
     pub start_block: Option<u64>,
 }
 

--- a/crates/topos/src/config/sequencer.rs
+++ b/crates/topos/src/config/sequencer.rs
@@ -32,6 +32,10 @@ pub struct SequencerConfig {
 
     /// OTLP service name, not used if not provided
     pub otlp_service_name: Option<String>,
+
+    /// Start syncing from particular block number
+    /// Default is to sync from genesis block 0
+    pub start_block: Option<u64>,
 }
 
 fn default_subnet_jsonrpc_endpoint() -> String {

--- a/crates/topos/tests/snapshots/sequencer__sequencer_help_display.snap
+++ b/crates/topos/tests/snapshots/sequencer__sequencer_help_display.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/topos/tests/sequencer.rs
-expression: result
+expression: "utils::sanitize_config_folder_path(result)"
 ---
 Run a full Topos Sequencer instance
 
@@ -27,6 +27,8 @@ Options:
           Socket of the opentelemetry agent endpoint If not provided open telemetry will not be used [env: TOPOS_OTLP_AGENT=]
       --otlp-service-name <OTLP_SERVICE_NAME>
           Otlp service name If not provided open telemetry will not be used [env: TOPOS_OTLP_SERVICE_NAME=]
+      --start-block <START_BLOCK>
+          Start syncing from particular block number Default is to sync from genesis block 0 [env: TOPOS_START_BLOCK=]
   -h, --help
           Print help
 

--- a/crates/topos/tests/snapshots/sequencer__sequencer_help_display.snap
+++ b/crates/topos/tests/snapshots/sequencer__sequencer_help_display.snap
@@ -28,7 +28,7 @@ Options:
       --otlp-service-name <OTLP_SERVICE_NAME>
           Otlp service name If not provided open telemetry will not be used [env: TOPOS_OTLP_SERVICE_NAME=]
       --start-block <START_BLOCK>
-          Start syncing from particular block number Default is to sync from genesis block 0 [env: TOPOS_START_BLOCK=]
+          Start synchronizing from particular block number Default is to sync from genesis block (0) [env: TOPOS_START_BLOCK=]
   -h, --help
           Print help
 


### PR DESCRIPTION
# Description

Add sequencer parameter `--start-block` to start syncing from particular subnet block.

Fixes TP-742


## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
