### PR TITLE
fix: tce private key encoding

### DIFF
--- a/crates/topos-tce-broadcast/src/task_manager_futures/mod.rs
+++ b/crates/topos-tce-broadcast/src/task_manager_futures/mod.rs
@@ -136,7 +136,7 @@ impl TaskManager {
                                     let prev = self.validator_store.get_certificate(&cert.prev_id);
                                     if matches!(prev, Ok(Some(_))) || cert.prev_id == topos_core::uci::INITIAL_CERTIFICATE_ID  {
                                         Self::start_task(
-                                            &mut self.running_tasks,
+                                            &self.running_tasks,
                                             task,
                                             task_context.sink.clone(),
                                             self.buffered_messages.remove(&cert.id),
@@ -164,7 +164,7 @@ impl TaskManager {
 
                                 let certificate_id= task.certificate_id;
                                 Self::start_task(
-                                    &mut self.running_tasks,
+                                    &self.running_tasks,
                                     task,
                                     context.sink.clone(),
                                     self.buffered_messages.remove(&certificate_id),
@@ -191,7 +191,7 @@ impl TaskManager {
     }
 
     fn start_task(
-        running_tasks: &mut RunningTasks,
+        running_tasks: &RunningTasks,
         task: Task,
         sink: mpsc::Sender<DoubleEchoCommand>,
         messages: Option<Vec<DoubleEchoCommand>>,

--- a/crates/topos-tce/src/lib.rs
+++ b/crates/topos-tce/src/lib.rs
@@ -48,9 +48,7 @@ pub async fn run(
 
     let message_signer = match &config.signing_key {
         Some(AuthKey::PrivateKey(pk)) => {
-            let bytes = pk.to_vec();
-            let bytes_str = std::str::from_utf8(&bytes)?;
-            MessageSigner::new(bytes_str)?
+            MessageSigner::new(&hex::encode(pk))?
         }
         _ => return Err(Box::try_from("Error, no singing key".to_string()).unwrap()),
     };

--- a/crates/topos-tce/src/lib.rs
+++ b/crates/topos-tce/src/lib.rs
@@ -47,9 +47,7 @@ pub async fn run(
     };
 
     let message_signer = match &config.signing_key {
-        Some(AuthKey::PrivateKey(pk)) => {
-            MessageSigner::new(&hex::encode(pk))?
-        }
+        Some(AuthKey::PrivateKey(pk)) => MessageSigner::new(&hex::encode(pk))?,
         _ => return Err(Box::try_from("Error, no singing key".to_string()).unwrap()),
     };
 

--- a/crates/topos/src/components/node/mod.rs
+++ b/crates/topos/src/components/node/mod.rs
@@ -110,9 +110,8 @@ pub(crate) async fn handle_command(
             // FIXME: Handle properly the `cmd`
             let config = NodeConfig::new(&node_path, None);
             info!(
-                "⚙️ Reading the configuration from {}/{}/config.toml",
-                home.display(),
-                config.base.name
+                "⚙️ Reading the configuration from {}/config.toml",
+                node_path.display()
             );
 
             // Load genesis pointed by the local config

--- a/crates/topos/src/config/genesis/mod.rs
+++ b/crates/topos/src/config/genesis/mod.rs
@@ -6,6 +6,7 @@ use std::{fs, path::PathBuf};
 use serde_json::Value;
 use topos_p2p::{Multiaddr, PeerId};
 use topos_tce_transport::ValidatorId;
+use tracing::{info};
 
 #[cfg(test)]
 pub(crate) mod tests;
@@ -23,8 +24,8 @@ pub enum Error {
 
 impl Genesis {
     pub fn new(path: PathBuf) -> Self {
+        info!("Reading subnet genesis file {}", path.display());
         let genesis_file = fs::File::open(&path).expect("opened file");
-
         let json: serde_json::Value =
             serde_json::from_reader(genesis_file).expect("genesis json parsed");
 

--- a/crates/topos/src/config/genesis/mod.rs
+++ b/crates/topos/src/config/genesis/mod.rs
@@ -6,7 +6,7 @@ use std::{fs, path::PathBuf};
 use serde_json::Value;
 use topos_p2p::{Multiaddr, PeerId};
 use topos_tce_transport::ValidatorId;
-use tracing::{info};
+use tracing::info;
 
 #[cfg(test)]
 pub(crate) mod tests;


### PR DESCRIPTION
# Description

Fix encoding of the TCE private key on startup.

Raw secret keys were converted to string using utf8 convert function which failed occasionally because keys are not valid utf8. Also, wallets used expect hex encoded raw key bytes, not utf8 character values of secret key bytes.

Fixes TP-746

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
