### PR TITLE
fix: private key parsing

### DIFF
--- a/crates/topos-crypto/src/messages.rs
+++ b/crates/topos-crypto/src/messages.rs
@@ -2,7 +2,7 @@ use ethers::signers::Signer;
 use ethers::signers::{LocalWallet, WalletError};
 use ethers::types::{RecoveryMessage, SignatureError};
 use ethers::utils::hash_message;
-use std::sync::Arc;
+use std::str::FromStr;
 use thiserror::Error;
 
 pub use ethers::types::{Address, Signature, H160};
@@ -19,16 +19,25 @@ pub struct MessageSigner {
     wallet: LocalWallet,
 }
 
+impl FromStr for MessageSigner {
+    type Err = MessageSignerError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let decoded = hex::decode(s).map_err(|_| MessageSignerError::PrivateKeyParsing)?;
+
+        Self::new(&decoded[..])
+    }
+}
+
 impl MessageSigner {
-    pub fn new(private_key: &str) -> Result<Arc<Self>, MessageSignerError> {
-        let wallet: LocalWallet = private_key
-            .parse()
+    pub fn new(private_key: &[u8]) -> Result<Self, MessageSignerError> {
+        let wallet: LocalWallet = LocalWallet::from_bytes(private_key)
             .map_err(|_| MessageSignerError::PrivateKeyParsing)?;
 
-        Ok(Arc::new(Self {
+        Ok(Self {
             public_address: wallet.address(),
             wallet,
-        }))
+        })
     }
 
     pub fn sign_message(&self, payload: &[u8]) -> Result<Signature, WalletError> {

--- a/crates/topos-crypto/tests/messages.rs
+++ b/crates/topos-crypto/tests/messages.rs
@@ -1,3 +1,5 @@
+use std::str::FromStr;
+
 use rstest::*;
 use topos_core::uci::CertificateId;
 use topos_crypto::messages::MessageSigner;
@@ -6,7 +8,7 @@ use topos_tce_transport::ValidatorId;
 #[rstest]
 pub fn test_signing_messages() {
     let message_signer_sender =
-        MessageSigner::new("122f3ae6ade1fd136b292cea4f6243c7811160352c8821528547a1fe7c459daf")
+        MessageSigner::from_str("122f3ae6ade1fd136b292cea4f6243c7811160352c8821528547a1fe7c459daf")
             .unwrap();
     let validator_id_sender = ValidatorId::from(message_signer_sender.public_address);
     let certificate_id = CertificateId::from_array([0u8; 32]);
@@ -20,7 +22,7 @@ pub fn test_signing_messages() {
         .expect("Cannot create Signature");
 
     let message_signer_receiver =
-        MessageSigner::new("a2e33a9bad88f7b7568228f51d5274c471a9217162d46f1533b6a290f0be1baf")
+        MessageSigner::from_str("a2e33a9bad88f7b7568228f51d5274c471a9217162d46f1533b6a290f0be1baf")
             .unwrap();
 
     let verify = message_signer_receiver.verify_signature(
@@ -35,7 +37,7 @@ pub fn test_signing_messages() {
 #[rstest]
 pub fn fails_to_verify_with_own_public_address() {
     let message_signer_sender =
-        MessageSigner::new("122f3ae6ade1fd136b292cea4f6243c7811160352c8821528547a1fe7c459daf")
+        MessageSigner::from_str("122f3ae6ade1fd136b292cea4f6243c7811160352c8821528547a1fe7c459daf")
             .unwrap();
     let validator_id_sender = ValidatorId::from(message_signer_sender.public_address);
     let certificate_id = CertificateId::from_array([0u8; 32]);
@@ -49,7 +51,7 @@ pub fn fails_to_verify_with_own_public_address() {
         .expect("Cannot create Signature");
 
     let message_signer_receiver =
-        MessageSigner::new("a2e33a9bad88f7b7568228f51d5274c471a9217162d46f1533b6a290f0be1baf")
+        MessageSigner::from_str("a2e33a9bad88f7b7568228f51d5274c471a9217162d46f1533b6a290f0be1baf")
             .unwrap();
     let validator_id_receiver = ValidatorId::from(message_signer_receiver.public_address);
 

--- a/crates/topos-tce-broadcast/benches/task_manager.rs
+++ b/crates/topos-tce-broadcast/benches/task_manager.rs
@@ -1,4 +1,5 @@
 use std::collections::HashSet;
+use std::str::FromStr;
 use std::sync::Arc;
 use tce_transport::{ReliableBroadcastParams, ValidatorId};
 use tokio::sync::{broadcast, mpsc, oneshot};
@@ -36,7 +37,8 @@ pub async fn processing_double_echo(n: u64, validator_store: Arc<ValidatorStore>
         },
     };
 
-    let message_signer: Arc<MessageSigner> = MessageSigner::new(PRIVATE_KEY).unwrap();
+    let message_signer: Arc<MessageSigner> =
+        Arc::new(MessageSigner::from_str(PRIVATE_KEY).unwrap());
 
     let mut validators = HashSet::new();
     let validator_id = ValidatorId::from(message_signer.public_address);

--- a/crates/topos-tce-broadcast/src/tests/mod.rs
+++ b/crates/topos-tce-broadcast/src/tests/mod.rs
@@ -2,6 +2,7 @@ use crate::double_echo::*;
 use crate::*;
 use rstest::*;
 use std::collections::HashSet;
+use std::str::FromStr;
 use std::time::Duration;
 use tce_transport::ReliableBroadcastParams;
 use tokio::sync::mpsc::Receiver;
@@ -57,7 +58,7 @@ async fn create_context(params: TceParams) -> (DoubleEcho, Context) {
         mpsc::channel::<oneshot::Sender<()>>(1);
     let (task_manager_message_sender, task_manager_message_receiver) = mpsc::channel(CHANNEL_SIZE);
 
-    let message_signer = MessageSigner::new(PRIVATE_KEY).unwrap();
+    let message_signer = Arc::new(MessageSigner::from_str(PRIVATE_KEY).unwrap());
 
     let mut validators = HashSet::new();
     let validator_id = ValidatorId::from(message_signer.public_address);
@@ -119,7 +120,7 @@ async fn reach_echo_threshold(double_echo: &mut DoubleEcho, cert: &Certificate) 
         .cloned()
         .collect::<Vec<_>>();
 
-    let message_signer = MessageSigner::new(PRIVATE_KEY).unwrap();
+    let message_signer = Arc::new(MessageSigner::from_str(PRIVATE_KEY).unwrap());
     let validator_id = ValidatorId::from(message_signer.public_address);
 
     let mut payload = Vec::new();
@@ -144,7 +145,7 @@ async fn reach_ready_threshold(double_echo: &mut DoubleEcho, cert: &Certificate)
         .cloned()
         .collect::<Vec<_>>();
 
-    let message_signer = MessageSigner::new(PRIVATE_KEY).unwrap();
+    let message_signer = Arc::new(MessageSigner::from_str(PRIVATE_KEY).unwrap());
 
     let validator_id = ValidatorId::from(message_signer.public_address);
 
@@ -170,7 +171,7 @@ async fn reach_delivery_threshold(double_echo: &mut DoubleEcho, cert: &Certifica
         .cloned()
         .collect::<Vec<_>>();
 
-    let message_signer = MessageSigner::new(PRIVATE_KEY).unwrap();
+    let message_signer = Arc::new(MessageSigner::from_str(PRIVATE_KEY).unwrap());
     let validator_id = ValidatorId::from(message_signer.public_address);
 
     let mut payload = Vec::new();

--- a/crates/topos-tce/src/lib.rs
+++ b/crates/topos-tce/src/lib.rs
@@ -47,11 +47,7 @@ pub async fn run(
     };
 
     let message_signer = match &config.signing_key {
-        Some(AuthKey::PrivateKey(pk)) => {
-            let bytes = pk.to_vec();
-            let bytes_str = std::str::from_utf8(&bytes)?;
-            MessageSigner::new(bytes_str)?
-        }
+        Some(AuthKey::PrivateKey(pk)) => Arc::new(MessageSigner::new(&pk[..])?),
         _ => return Err(Box::try_from("Error, no singing key".to_string()).unwrap()),
     };
 

--- a/crates/topos-test-sdk/src/tce/protocol.rs
+++ b/crates/topos-test-sdk/src/tce/protocol.rs
@@ -1,5 +1,6 @@
 use futures::Stream;
 use std::collections::HashSet;
+use std::str::FromStr;
 use std::sync::Arc;
 use tokio::sync::broadcast;
 use topos_crypto::messages::MessageSigner;
@@ -18,7 +19,7 @@ pub async fn create_reliable_broadcast_client(
     ReliableBroadcastClient,
     impl Stream<Item = ProtocolEvents> + Unpin,
 ) {
-    let message_signer = MessageSigner::new(PRIVATE_KEY).unwrap();
+    let message_signer = Arc::new(MessageSigner::from_str(PRIVATE_KEY).unwrap());
 
     let mut validators = HashSet::new();
     let validator_id = ValidatorId::from(message_signer.public_address);

--- a/crates/topos/src/components/tce/mod.rs
+++ b/crates/topos/src/components/tce/mod.rs
@@ -97,7 +97,12 @@ pub(crate) async fn handle_command(
                 signing_key: cmd
                     .local_validator_private_key
                     .clone()
-                    .map(|s| AuthKey::PrivateKey(s.as_bytes().to_vec())),
+                    .map(|s| {
+                        hex::decode(s)
+                            .map(AuthKey::PrivateKey)
+                            .map_err(|_| Box::new(topos::Error::InvalidPrivateKey))
+                    })
+                    .map_or(Ok(None), |v| v.map(Some))?,
                 tce_addr: cmd.tce_ext_host,
                 tce_local_port: cmd.tce_local_port,
                 tce_params: cmd.tce_params,

--- a/crates/topos/src/lib.rs
+++ b/crates/topos/src/lib.rs
@@ -21,6 +21,8 @@ pub enum Error {
     InvalidReleaseMetadata,
     #[error("File io error: {0}")]
     File(std::io::Error),
+    #[error("Invalid private key")]
+    InvalidPrivateKey,
 }
 
 fn map_arch(arch: &str) -> &str {


### PR DESCRIPTION
# Description

This PR is fixing an issue while trying to parse the private key into a `LocalWallet`, instead of trying to parse `bytes` into `ut8 str` I directly use the `bytes` to generate the `wallet`.

## PR Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
