### PR TITLE
fix: cert id and subnet id conversions

### DIFF
--- a/crates/topos-api/src/grpc/conversions/uci/v1/uci.rs
+++ b/crates/topos-api/src/grpc/conversions/uci/v1/uci.rs
@@ -137,11 +137,11 @@ fn test_proto_uci_certificate_conversion_id_random_0x() {
 fn test_proto_uci_certificate_conversion_id_starts_with_0x() {
     use crate::grpc::shared::v1::{CertificateId, Frost, StarkProof, SubnetId};
     let mut prev_id = vec![b'0', b'x'];
-    let id = "504b5d01948bc777ba1510ba92a901f516408e4b2a1a5b97fed719430acc9ec9";
     prev_id.append(
         &mut hex::decode("aac03cadfff6846c9ce72956eee2498011dd7b08689565d6f29e25c0a967ef14")
             .expect("Valid id"),
     );
+    let id = "504b5d01948bc777ba1510ba92a901f516408e4b2a1a5b97fed719430acc9ec9";
     let valid_cert = proto_v1::Certificate {
         prev_id: Some(CertificateId { value: prev_id }),
         id: Some(CertificateId {
@@ -172,7 +172,7 @@ fn test_proto_uci_certificate_conversion_id_starts_with_0x() {
     let id = "AA4b5d01948bc777ba1510ba92a901f516408e4b2a1a5b97fed719430acc9ec9"
         .to_string()
         .into_bytes();
-    let valid_cert = proto_v1::Certificate {
+    let valid_cert_2 = proto_v1::Certificate {
         prev_id: Some(CertificateId { value: prev_id }),
         id: Some(CertificateId { value: id }),
         source_subnet_id: Some(SubnetId::from([0u8; 32])),
@@ -183,7 +183,7 @@ fn test_proto_uci_certificate_conversion_id_starts_with_0x() {
         signature: Some(Frost { value: Vec::new() }),
         ..Default::default()
     };
-    let cert: topos_uci::Certificate = match topos_uci::Certificate::try_from(valid_cert) {
+    let cert_2: topos_uci::Certificate = match topos_uci::Certificate::try_from(valid_cert_2) {
         Ok(cert) => cert,
         Err(e) => {
             panic!("Unable to perform certificate conversion: {e}");
@@ -192,6 +192,6 @@ fn test_proto_uci_certificate_conversion_id_starts_with_0x() {
 
     println!(
         "Second certificate converted prev_id={}, id={}",
-        cert.prev_id, cert.id
+        cert_2.prev_id, cert_2.id
     );
 }

--- a/crates/topos-api/src/grpc/conversions/uci/v1/uci.rs
+++ b/crates/topos-api/src/grpc/conversions/uci/v1/uci.rs
@@ -81,3 +81,117 @@ impl From<topos_uci::Certificate> for proto_v1::Certificate {
         }
     }
 }
+
+#[test]
+fn test_proto_uci_certificate_conversion_id_random_0x() {
+    use crate::grpc::shared::v1::{CertificateId, Frost, StarkProof, SubnetId};
+    let valid_cert = proto_v1::Certificate {
+        prev_id: Some(CertificateId {
+            value: vec![
+                134, 103, 37, 44, 159, 78, 218, 73, 112, 17, 202, 189, 112, 180, 121, 0, 12, 128,
+                186, 116, 161, 18, 122, 129, 75, 151, 144, 95, 63, 203, 218, 69,
+            ],
+        }),
+        source_subnet_id: Some(SubnetId {
+            value: vec![
+                98, 139, 93, 91, 125, 115, 135, 224, 46, 222, 68, 33, 52, 2, 83, 179, 100, 2, 44,
+                97, 103, 55, 128, 90, 14, 40, 56, 72, 66, 59, 0, 181,
+            ],
+        }),
+        state_root: vec![
+            145, 239, 242, 24, 12, 214, 83, 202, 223, 162, 240, 11, 146, 240, 28, 179, 163, 174,
+            70, 6, 216, 40, 150, 1, 195, 33, 156, 132, 21, 43, 6, 236,
+        ],
+        tx_root_hash: vec![
+            86, 232, 31, 23, 27, 204, 85, 166, 255, 131, 69, 230, 146, 192, 248, 110, 91, 72, 224,
+            27, 153, 108, 173, 192, 1, 98, 47, 181, 227, 99, 180, 33,
+        ],
+        receipts_root_hash: vec![
+            86, 232, 31, 23, 27, 204, 85, 166, 255, 131, 69, 230, 146, 192, 248, 110, 91, 72, 224,
+            27, 153, 108, 173, 192, 1, 98, 47, 181, 227, 99, 180, 33,
+        ],
+        target_subnets: Vec::new(),
+        verifier: 0,
+        id: Some(CertificateId {
+            value: vec![
+                48, 120, 230, 118, 216, 103, 205, 65, 12, 143, 205, 166, 153, 107, 194, 94, 158,
+                29, 135, 167, 231, 50, 238, 173, 96, 165, 27, 215, 255, 94, 18, 199,
+            ],
+        }),
+        proof: Some(StarkProof { value: Vec::new() }),
+        signature: Some(Frost {
+            value: vec![
+                76, 181, 52, 25, 163, 103, 87, 142, 229, 64, 163, 77, 11, 225, 135, 96, 181, 34,
+                168, 13, 152, 69, 90, 202, 11, 235, 122, 214, 103, 26, 31, 109, 94, 117, 53, 83,
+                195, 74, 47, 175, 189, 3, 134, 164, 186, 179, 73, 86, 202, 172, 213, 195, 160, 139,
+                240, 230, 103, 81, 227, 99, 241, 130, 157, 188,
+            ],
+        }),
+    };
+    if let Err(e) = topos_uci::Certificate::try_from(valid_cert) {
+        panic!("Unable to perform certificate conversion: {e}");
+    };
+}
+
+#[test]
+fn test_proto_uci_certificate_conversion_id_starts_with_0x() {
+    use crate::grpc::shared::v1::{CertificateId, Frost, StarkProof, SubnetId};
+    let mut prev_id = vec![b'0', b'x'];
+    let id = "504b5d01948bc777ba1510ba92a901f516408e4b2a1a5b97fed719430acc9ec9";
+    prev_id.append(
+        &mut hex::decode("aac03cadfff6846c9ce72956eee2498011dd7b08689565d6f29e25c0a967ef14")
+            .expect("Valid id"),
+    );
+    let valid_cert = proto_v1::Certificate {
+        prev_id: Some(CertificateId { value: prev_id }),
+        id: Some(CertificateId {
+            value: hex::decode(id).expect("Valid id"),
+        }),
+        source_subnet_id: Some(SubnetId::from([0u8; 32])),
+        state_root: [0u8; 32].to_vec(),
+        tx_root_hash: [0u8; 32].to_vec(),
+        receipts_root_hash: [0u8; 32].to_vec(),
+        proof: Some(StarkProof { value: Vec::new() }),
+        signature: Some(Frost { value: Vec::new() }),
+        ..Default::default()
+    };
+    let cert: topos_uci::Certificate = match topos_uci::Certificate::try_from(valid_cert) {
+        Ok(cert) => cert,
+        Err(e) => {
+            panic!("Unable to perform certificate conversion: {e}");
+        }
+    };
+    println!(
+        "First certificate converted prev_id={}, id={}",
+        cert.prev_id, cert.id
+    );
+
+    let prev_id = "0xFF4b5d01948bc777ba1510ba92a901f516408e4b2a1a5b97fed719430acc9ec9"
+        .to_string()
+        .into_bytes();
+    let id = "AA4b5d01948bc777ba1510ba92a901f516408e4b2a1a5b97fed719430acc9ec9"
+        .to_string()
+        .into_bytes();
+    let valid_cert = proto_v1::Certificate {
+        prev_id: Some(CertificateId { value: prev_id }),
+        id: Some(CertificateId { value: id }),
+        source_subnet_id: Some(SubnetId::from([0u8; 32])),
+        state_root: [0u8; 32].to_vec(),
+        tx_root_hash: [0u8; 32].to_vec(),
+        receipts_root_hash: [0u8; 32].to_vec(),
+        proof: Some(StarkProof { value: Vec::new() }),
+        signature: Some(Frost { value: Vec::new() }),
+        ..Default::default()
+    };
+    let cert: topos_uci::Certificate = match topos_uci::Certificate::try_from(valid_cert) {
+        Ok(cert) => cert,
+        Err(e) => {
+            panic!("Unable to perform certificate conversion: {e}");
+        }
+    };
+
+    println!(
+        "Second certificate converted prev_id={}, id={}",
+        cert.prev_id, cert.id
+    );
+}

--- a/crates/topos-uci/src/certificate_id.rs
+++ b/crates/topos-uci/src/certificate_id.rs
@@ -65,8 +65,8 @@ impl TryFrom<&[u8]> for CertificateId {
 
         if length != CERTIFICATE_ID_LENGTH && length != HEX_CERTIFICATE_ID_LENGTH {
             return Err(Error::ValidationError(format!(
-                "invalid certificate id length {length} should be byte array \
-                 {CERTIFICATE_ID_LENGTH} or hex encoded string of size {HEX_CERTIFICATE_ID_LENGTH}"
+                "invalid certificate id length {length} - should be {CERTIFICATE_ID_LENGTH} bytes \
+                 array or hex encoded string of size {HEX_CERTIFICATE_ID_LENGTH}"
             )));
         }
 
@@ -75,7 +75,7 @@ impl TryFrom<&[u8]> for CertificateId {
         if length == HEX_CERTIFICATE_ID_LENGTH {
             let value = hex::decode(value).map_err(|_| {
                 Error::ValidationError(format!(
-                    "invalid hex encoded certificate id string {value:?}"
+                    "invalid hex encoded certificate id string: {value:?}"
                 ))
             })?;
 

--- a/crates/topos-uci/src/lib.rs
+++ b/crates/topos-uci/src/lib.rs
@@ -35,8 +35,8 @@ const DUMMY_STARK_DELAY: time::Duration = time::Duration::from_millis(0);
 
 #[derive(Debug, Error)]
 pub enum Error {
-    #[error("certificate validation error")]
-    ValidationError,
+    #[error("certificate validation error: {0}")]
+    ValidationError(String),
 
     #[error("topos crypto error: (0)")]
     CryptoError(#[from] topos_crypto::Error),

--- a/crates/topos-uci/src/subnet_id.rs
+++ b/crates/topos-uci/src/subnet_id.rs
@@ -58,7 +58,7 @@ impl TryFrom<&[u8]> for SubnetId {
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         if value.len() != SUBNET_ID_LENGTH {
             return Err(Error::ValidationError(format!(
-                "invalid subnet id length {}",
+                "invalid subnet id of length {}, expected length {SUBNET_ID_LENGTH}",
                 value.len()
             )));
         }
@@ -77,7 +77,7 @@ impl FromStr for SubnetId {
         let s = if s.starts_with("0x") {
             hex::decode(&s[2..s.len()]).map_err(|e| {
                 Error::ValidationError(format!(
-                    "could not decode subnet id hex encoded string {s} : {e}"
+                    "could not decode subnet id hex encoded string '{s}' error: {e}"
                 ))
             })?
         } else {

--- a/crates/topos-uci/src/subnet_id.rs
+++ b/crates/topos-uci/src/subnet_id.rs
@@ -57,7 +57,10 @@ impl TryFrom<&[u8]> for SubnetId {
 
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         if value.len() != SUBNET_ID_LENGTH {
-            return Err(Error::ValidationError);
+            return Err(Error::ValidationError(format!(
+                "invalid subnet id length {}",
+                value.len()
+            )));
         }
 
         let mut id = [0; SUBNET_ID_LENGTH];
@@ -72,7 +75,11 @@ impl FromStr for SubnetId {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let s = if s.starts_with("0x") {
-            hex::decode(&s[2..s.len()]).map_err(|_| Error::ValidationError)?
+            hex::decode(&s[2..s.len()]).map_err(|e| {
+                Error::ValidationError(format!(
+                    "could not decode subnet id hex encoded string {s} : {e}"
+                ))
+            })?
         } else {
             s.as_bytes().to_vec()
         };


### PR DESCRIPTION
# Description

Fix certificate id conversion where `0x` start of random id was removed because it indicates hex encoded string

Fixes TP-712
## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
