### PR TITLE
feat: adding GraphQL Subscription

### DIFF
--- a/crates/topos-api/src/graphql/errors.rs
+++ b/crates/topos-api/src/graphql/errors.rs
@@ -14,4 +14,10 @@ pub enum GraphQLServerError {
 
     #[error("Certificate not found")]
     CertificateNotFound,
+
+    #[error("Unable to create transient stream: {0}")]
+    TransientStream(String),
+
+    #[error("Internal API error: {0}")]
+    InternalError(&'static str),
 }

--- a/crates/topos-tce-api/src/graphql/mod.rs
+++ b/crates/topos-tce-api/src/graphql/mod.rs
@@ -1,3 +1,5 @@
 pub mod builder;
 mod query;
 mod routes;
+#[cfg(test)]
+mod tests;

--- a/crates/topos-tce-api/src/graphql/tests.rs
+++ b/crates/topos-tce-api/src/graphql/tests.rs
@@ -1,0 +1,122 @@
+use std::time::Duration;
+
+use crate::{
+    graphql::query::{QueryRoot, SubscriptionRoot},
+    runtime::InternalRuntimeCommand,
+    stream::TransientStream,
+};
+use async_graphql::{http, value, EmptyMutation, Schema};
+use futures::{SinkExt, StreamExt};
+use rstest::rstest;
+use test_log::test;
+use tokio::sync::{mpsc, oneshot};
+use uuid::Uuid;
+
+#[rstest]
+#[test(tokio::test)]
+#[timeout(Duration::from_secs(2))]
+async fn requesting_transient_stream_from_graphql() {
+    let (sender, mut receiver) = mpsc::channel(1);
+
+    tokio::spawn(async move {
+        let mut v = Vec::new();
+        while let Some(query) = receiver.recv().await {
+            if let InternalRuntimeCommand::NewTransientStream { sender } = query {
+                let (notifier, notifier_receiver) = oneshot::channel();
+                v.push(notifier_receiver);
+
+                let (_s, inner) = mpsc::channel(10);
+                _ = sender.send(Ok(TransientStream {
+                    stream_id: Uuid::new_v4(),
+                    notifier: Some(notifier),
+                    inner,
+                }));
+            }
+        }
+    });
+
+    let root = SubscriptionRoot {};
+
+    let result = root.new_transient_stream(&sender).await;
+
+    assert!(result.is_ok());
+}
+
+#[rstest]
+#[timeout(Duration::from_secs(4))]
+#[test(tokio::test)]
+async fn open_watch_certificate_delivered() {
+    let (mut tx, rx) = futures::channel::mpsc::unbounded();
+    let (sender, mut receiver): (mpsc::Sender<InternalRuntimeCommand>, _) = mpsc::channel(1);
+
+    tokio::spawn(async move {
+        let mut v = Vec::new();
+        while let Some(query) = receiver.recv().await {
+            if let InternalRuntimeCommand::NewTransientStream { sender } = query {
+                let (notifier, notifier_receiver) = oneshot::channel();
+                v.push(notifier_receiver);
+
+                let (_s, inner) = mpsc::channel(10);
+                _ = sender.send(Ok(TransientStream {
+                    stream_id: Uuid::new_v4(),
+                    notifier: Some(notifier),
+                    inner,
+                }));
+            }
+        }
+    });
+    let subscription = SubscriptionRoot {};
+    let schema = Schema::build(QueryRoot, EmptyMutation, subscription)
+        .data(sender)
+        .finish();
+
+    let mut stream = http::WebSocket::new(schema, rx, http::WebSocketProtocols::GraphQLWS);
+
+    tx.send(
+        serde_json::to_string(&value!({
+            "type": "connection_init",
+        }))
+        .unwrap(),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(&stream.next().await.unwrap().unwrap_text())
+            .unwrap(),
+        serde_json::json!({
+            "type": "connection_ack",
+        }),
+    );
+
+    tx.send(
+        serde_json::to_string(&value!({
+            "type": "start",
+            "id": "1",
+            "payload": {
+                "query": "subscription onCertificates {
+                              watchDeliveredCertificates {
+                                id
+                                prevId
+                                sourceSubnetId
+                                targetSubnets {
+                                  value
+                                }
+                              }
+                            }"
+            },
+        }))
+        .unwrap(),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(&stream.next().await.unwrap().unwrap_text())
+            .unwrap(),
+        serde_json::json!({
+            "type": "complete",
+            "id": "1",
+        }),
+    );
+}

--- a/crates/topos-tce-api/src/lib.rs
+++ b/crates/topos-tce-api/src/lib.rs
@@ -7,6 +7,13 @@ mod stream;
 #[cfg(test)]
 mod tests;
 
+pub(crate) mod constants {
+    /// Constant size of every channel in the crate
+    pub(crate) const CHANNEL_SIZE: usize = 2048;
+
+    /// Constant size of every transient stream channel in the crate
+    pub(crate) const TRANSIENT_STREAM_CHANNEL_SIZE: usize = 1024;
+}
 pub use runtime::{
     error::RuntimeError, Runtime, RuntimeClient, RuntimeCommand, RuntimeContext, RuntimeEvent,
 };

--- a/crates/topos-tce-api/src/runtime/builder.rs
+++ b/crates/topos-tce-api/src/runtime/builder.rs
@@ -162,7 +162,7 @@ impl RuntimeBuilder {
             api_event_sender,
             shutdown: shutdown_receiver,
             streams: Default::default(),
-            transient_stream: HashMap::new(),
+            transient_streams: HashMap::new(),
         };
         let runtime_handler = spawn(runtime.launch());
 

--- a/crates/topos-tce-api/src/runtime/builder.rs
+++ b/crates/topos-tce-api/src/runtime/builder.rs
@@ -11,8 +11,9 @@ use topos_tce_storage::{
 };
 
 use crate::{
-    graphql::builder::ServerBuilder as GraphQLBuilder, grpc::builder::ServerBuilder,
-    metrics::builder::ServerBuilder as MetricsBuilder, Runtime, RuntimeClient, RuntimeEvent,
+    constants::CHANNEL_SIZE, graphql::builder::ServerBuilder as GraphQLBuilder,
+    grpc::builder::ServerBuilder, metrics::builder::ServerBuilder as MetricsBuilder, Runtime,
+    RuntimeClient, RuntimeEvent,
 };
 
 #[derive(Default)]
@@ -86,8 +87,9 @@ impl RuntimeBuilder {
         impl Stream<Item = RuntimeEvent>,
         RuntimeContext,
     ) {
-        let (command_sender, internal_runtime_command_receiver) = mpsc::channel(2048);
-        let (api_event_sender, api_event_receiver) = mpsc::channel(2048);
+        let (internal_runtime_command_sender, internal_runtime_command_receiver) =
+            mpsc::channel(CHANNEL_SIZE);
+        let (api_event_sender, api_event_receiver) = mpsc::channel(CHANNEL_SIZE);
 
         let (health_reporter, tce_status, grpc) = ServerBuilder::default()
             .with_store(
@@ -97,12 +99,12 @@ impl RuntimeBuilder {
                     .expect("Unable to build gRPC Server, Store is missing"),
             )
             .with_peer_id(self.local_peer_id)
-            .command_sender(command_sender.clone())
+            .command_sender(internal_runtime_command_sender.clone())
             .serve_addr(self.grpc_socket_addr)
             .build()
             .await;
 
-        let (command_sender, runtime_command_receiver) = mpsc::channel(2048);
+        let (command_sender, runtime_command_receiver) = mpsc::channel(CHANNEL_SIZE);
         let (shutdown_channel, shutdown_receiver) = mpsc::channel::<oneshot::Sender<()>>(1);
 
         let grpc_handler = spawn(grpc);
@@ -117,6 +119,7 @@ impl RuntimeBuilder {
                         .map(|store| store.get_fullnode_store())
                         .expect("Unable to build GraphQL Server, Store is missing"),
                 )
+                .runtime(internal_runtime_command_sender.clone())
                 .serve_addr(Some(graphql_addr))
                 .build();
             spawn(graphql.await)
@@ -159,6 +162,7 @@ impl RuntimeBuilder {
             api_event_sender,
             shutdown: shutdown_receiver,
             streams: Default::default(),
+            transient_stream: HashMap::new(),
         };
         let runtime_handler = spawn(runtime.launch());
 

--- a/crates/topos-tce-api/src/runtime/commands.rs
+++ b/crates/topos-tce-api/src/runtime/commands.rs
@@ -6,7 +6,7 @@ use topos_p2p::PeerId;
 use topos_tce_storage::types::PendingResult;
 use uuid::Uuid;
 
-use crate::stream::{Stream, StreamCommand};
+use crate::stream::{Stream, StreamCommand, TransientStream};
 
 use super::error::RuntimeError;
 
@@ -56,5 +56,10 @@ pub(crate) enum InternalRuntimeCommand {
     GetSourceHead {
         subnet_id: SubnetId,
         sender: oneshot::Sender<Result<Option<(u64, Certificate)>, RuntimeError>>,
+    },
+
+    /// Ask the creation of a new TransientStream
+    NewTransientStream {
+        sender: oneshot::Sender<Result<TransientStream, RuntimeError>>,
     },
 }

--- a/crates/topos-tce-api/src/runtime/mod.rs
+++ b/crates/topos-tce-api/src/runtime/mod.rs
@@ -1,4 +1,4 @@
-use futures::{stream::FuturesUnordered, StreamExt};
+use futures::{stream::FuturesUnordered, FutureExt, StreamExt, TryFutureExt};
 use std::{
     collections::{hash_map::Entry, HashMap, HashSet},
     future,
@@ -12,7 +12,7 @@ use tokio::{
     task::JoinHandle,
 };
 use tonic_health::server::HealthReporter;
-use topos_core::uci::SubnetId;
+use topos_core::uci::{Certificate, SubnetId};
 use topos_core::{api::grpc::checkpoints::TargetStreamPosition, types::CertificateDelivered};
 use topos_core::{
     api::grpc::tce::v1::api_service_server::ApiServiceServer,
@@ -27,8 +27,9 @@ use tracing::{debug, error, info};
 use uuid::Uuid;
 
 use crate::{
+    constants::TRANSIENT_STREAM_CHANNEL_SIZE,
     grpc::TceGrpcService,
-    stream::{StreamCommand, StreamError, StreamErrorKind},
+    stream::{StreamCommand, StreamError, StreamErrorKind, TransientStream},
 };
 
 pub mod builder;
@@ -58,6 +59,7 @@ pub struct Runtime {
     pub(crate) broadcast_stream: broadcast::Receiver<CertificateDeliveredWithPositions>,
 
     pub(crate) storage: StorageClient,
+    pub(crate) transient_stream: HashMap<Uuid, Sender<Certificate>>,
     /// Streams that are currently active (with a valid handshake)
     pub(crate) active_streams: HashMap<Uuid, Sender<StreamCommand>>,
     /// Streams that are currently in negotiation
@@ -222,6 +224,36 @@ impl Runtime {
 
     async fn handle_internal_command(&mut self, command: InternalRuntimeCommand) {
         match command {
+            InternalRuntimeCommand::NewTransientStream { sender } => {
+                let stream_id = Uuid::new_v4();
+                info!("Opening a new transient stream with UUID {stream_id}");
+
+                let (stream, receiver) = mpsc::channel(TRANSIENT_STREAM_CHANNEL_SIZE);
+                let (shutdown, shutdown_recv) = oneshot::channel();
+                self.transient_stream.insert(stream_id, stream);
+
+                self.streams.push(
+                    shutdown_recv
+                        .map_err(move |_| StreamError {
+                            stream_id,
+                            kind: StreamErrorKind::StreamClosed,
+                        })
+                        .boxed(),
+                );
+
+                if sender
+                    .send(Ok(TransientStream {
+                        stream_id,
+                        inner: receiver,
+                        notifier: Some(shutdown),
+                    }))
+                    .is_err()
+                {
+                    error!("Unable to send new TransientStream");
+                    _ = self.transient_stream.remove(&stream_id);
+                }
+            }
+
             InternalRuntimeCommand::NewStream {
                 stream,
                 command_sender,


### PR DESCRIPTION
# Description

This PR is adding `GraphQL` subscriptions to the current API implementation. It introduces the basic functionality and creates the new `TransientStream` struct to manage those new streams.

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
