### PR TITLE
feat: node flag for external edge

### DIFF
--- a/crates/topos-tce-broadcast/src/task_manager_futures/mod.rs
+++ b/crates/topos-tce-broadcast/src/task_manager_futures/mod.rs
@@ -136,7 +136,7 @@ impl TaskManager {
                                     let prev = self.validator_store.get_certificate(&cert.prev_id);
                                     if matches!(prev, Ok(Some(_))) || cert.prev_id == topos_core::uci::INITIAL_CERTIFICATE_ID  {
                                         Self::start_task(
-                                            &mut self.running_tasks,
+                                            &self.running_tasks,
                                             task,
                                             task_context.sink.clone(),
                                             self.buffered_messages.remove(&cert.id),
@@ -164,7 +164,7 @@ impl TaskManager {
 
                                 let certificate_id= task.certificate_id;
                                 Self::start_task(
-                                    &mut self.running_tasks,
+                                    &self.running_tasks,
                                     task,
                                     context.sink.clone(),
                                     self.buffered_messages.remove(&certificate_id),
@@ -191,7 +191,7 @@ impl TaskManager {
     }
 
     fn start_task(
-        running_tasks: &mut RunningTasks,
+        running_tasks: &RunningTasks,
         task: Task,
         sink: mpsc::Sender<DoubleEchoCommand>,
         messages: Option<Vec<DoubleEchoCommand>>,

--- a/crates/topos/src/components/node/commands/up.rs
+++ b/crates/topos/src/components/node/commands/up.rs
@@ -12,4 +12,9 @@ pub struct Up {
     /// If omitted, the local FS secrets manager is used
     #[arg(long, env = "TOPOS_SECRETS_MANAGER")]
     pub secrets_config: Option<String>,
+
+    /// Do not run background edge process as part of node
+    /// Usable for cases where edge edpoint is available as infura (or similar cluod provider) endpoint
+    #[arg(long, env = "EXTERNAL_EDGE_NODE", action)]
+    pub external_edge_node: bool,
 }

--- a/crates/topos/src/components/node/commands/up.rs
+++ b/crates/topos/src/components/node/commands/up.rs
@@ -13,8 +13,8 @@ pub struct Up {
     #[arg(long, env = "TOPOS_SECRETS_MANAGER")]
     pub secrets_config: Option<String>,
 
-    /// Do not run background edge process as part of node
-    /// Usable for cases where edge edpoint is available as infura (or similar cluod provider) endpoint
-    #[arg(long, env = "EXTERNAL_EDGE_NODE", action)]
-    pub external_edge_node: bool,
+    /// Defines that an external edge node will be use, replacing the one normally run by the node.
+    /// Usable for cases where edge endpoint is available as infura (or similar cloud provider) endpoint
+    #[arg(long, env = "TOPOS_NO_EDGE_PROCESS", action)]
+    pub no_edge_process: bool,
 }

--- a/crates/topos/src/components/node/mod.rs
+++ b/crates/topos/src/components/node/mod.rs
@@ -138,24 +138,27 @@ pub(crate) async fn handle_command(
 
             let mut processes = FuturesUnordered::new();
 
-            // Edge
+            // Edge node
             if cmd.no_edge_process {
                 info!("Using external edge node, skip running of local edge instance...")
-            } else {
+            } else if let Some(edge_config) = config.edge {
                 let data_dir = node_path.clone();
                 info!(
                     "Spawning edge process with genesis file: {}, data directory: {}, additional \
                      edge arguments: {:?}",
                     genesis.path.display(),
                     data_dir.display(),
-                    config.edge.as_ref().expect("valid edge configuration").args
+                    edge_config.args
                 );
                 processes.push(services::spawn_edge_process(
                     edge_path.join(BINARY_NAME),
                     data_dir,
                     genesis.path.clone(),
-                    config.edge.unwrap().args,
+                    edge_config.args,
                 ));
+            } else {
+                error!("Missing edge configuration, could not run edge node!");
+                std::process::exit(1);
             }
 
             // Sequencer

--- a/crates/topos/src/components/node/mod.rs
+++ b/crates/topos/src/components/node/mod.rs
@@ -139,7 +139,7 @@ pub(crate) async fn handle_command(
             let mut processes = FuturesUnordered::new();
 
             // Edge
-            if cmd.external_edge_node {
+            if cmd.no_edge_process {
                 info!("Using external edge node, skip running of local edge instance...")
             } else {
                 let data_dir = node_path.clone();
@@ -148,7 +148,7 @@ pub(crate) async fn handle_command(
                      edge arguments: {:?}",
                     genesis.path.display(),
                     data_dir.display(),
-                    config.edge.as_ref().unwrap().args
+                    config.edge.as_ref().expect("valid edge configuration").args
                 );
                 processes.push(services::spawn_edge_process(
                     edge_path.join(BINARY_NAME),

--- a/crates/topos/src/components/node/mod.rs
+++ b/crates/topos/src/components/node/mod.rs
@@ -110,9 +110,8 @@ pub(crate) async fn handle_command(
             // FIXME: Handle properly the `cmd`
             let config = NodeConfig::new(&node_path, None);
             info!(
-                "⚙️ Reading the configuration from {}/{}/config.toml",
-                home.display(),
-                config.base.name
+                "⚙️ Reading the configuration from {}/config.toml",
+                node_path.display()
             );
 
             // Load genesis pointed by the local config
@@ -140,18 +139,37 @@ pub(crate) async fn handle_command(
             let mut processes = FuturesUnordered::new();
 
             // Edge
-            let data_dir = node_path.clone();
-            processes.push(services::spawn_edge_process(
-                edge_path.join(BINARY_NAME),
-                data_dir,
-                genesis.path.clone(),
-                config.edge.unwrap().args,
-            ));
+            if cmd.external_edge_node {
+                info!("Using external edge node, skip running of local edge instance...")
+            } else {
+                let data_dir = node_path.clone();
+                info!(
+                    "Spawning edge process with genesis file: {}, data directory: {}, additional \
+                     edge arguments: {:?}",
+                    genesis.path.display(),
+                    data_dir.display(),
+                    config.edge.as_ref().unwrap().args
+                );
+                processes.push(services::spawn_edge_process(
+                    edge_path.join(BINARY_NAME),
+                    data_dir,
+                    genesis.path.clone(),
+                    config.edge.unwrap().args,
+                ));
+            }
 
             // Sequencer
             if matches!(config.base.role, NodeRole::Sequencer) {
+                let sequencer_config = config
+                    .sequencer
+                    .clone()
+                    .expect("valid sequencer configuration");
+                info!(
+                    "Running sequencer with configuration {:?}",
+                    sequencer_config
+                );
                 processes.push(services::spawn_sequencer_process(
-                    config.sequencer.clone().unwrap(),
+                    sequencer_config,
                     &keys,
                     (shutdown_token.clone(), shutdown_sender.clone()),
                 ));
@@ -159,6 +177,7 @@ pub(crate) async fn handle_command(
 
             // TCE
             if config.base.subnet_id == "topos" {
+                info!("Running topos TCE service...",);
                 processes.push(services::spawn_tce_process(
                     config.tce.clone().unwrap(),
                     keys,

--- a/crates/topos/src/components/node/services.rs
+++ b/crates/topos/src/components/node/services.rs
@@ -120,7 +120,6 @@ pub fn spawn_edge_process(
     genesis_path: PathBuf,
     edge_args: HashMap<String, String>,
 ) -> JoinHandle<Result<(), Errors>> {
-    debug!("Edge args: {edge_args:?}");
     spawn(async move {
         match CommandConfig::new(edge_path)
             .server(&data_dir, &genesis_path, edge_args)

--- a/crates/topos/src/config/genesis/mod.rs
+++ b/crates/topos/src/config/genesis/mod.rs
@@ -6,6 +6,7 @@ use std::{fs, path::PathBuf};
 use serde_json::Value;
 use topos_p2p::{Multiaddr, PeerId};
 use topos_tce_transport::ValidatorId;
+use tracing::info;
 
 #[cfg(test)]
 pub(crate) mod tests;
@@ -23,6 +24,7 @@ pub enum Error {
 
 impl Genesis {
     pub fn new(path: PathBuf) -> Self {
+        info!("Reading subnet genesis file {}", path.display());
         let genesis_file = fs::File::open(&path).expect("opened file");
 
         let json: serde_json::Value =


### PR DESCRIPTION
# Description

For `topos node up` cli command, added flag `--external-edge-node` indicating that edge process should not be started.

Sequencer will connect to the edge node pointed by configuration

Fixes TP-741

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
