### PR TITLE
test: update path for github actions stub

### DIFF
--- a/.github/workflows/grpc-client-stubs.yml
+++ b/.github/workflows/grpc-client-stubs.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
     branches: [main]
     paths:
-      - "**.proto"
+      - "./crates/topos-api/**.proto"
 
 jobs:
   js-grpc:


### PR DESCRIPTION
# Description

Update Github actions `gRPC` stub to prevent false positive change detection with tests `gRPC` protobuf files.
The goal is to execute the action only when the changes contains `./crates/topos-api/**.proto` 

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
