### PR TITLE
feat: add dedicated websocket cli parameter

### DIFF
--- a/crates/topos-sequencer-subnet-runtime/tests/subnet_contract.rs
+++ b/crates/topos-sequencer-subnet-runtime/tests/subnet_contract.rs
@@ -790,11 +790,11 @@ async fn test_subnet_certificate_get_checkpoints_call(
     let context = context_running_subnet_node.await;
     let subnet_smart_contract_address =
         "0x".to_string() + &hex::encode(context.i_topos_core.address());
-    let subnet_jsonrpc_endpoint = context.jsonrpc();
+    let subnet_jsonrpc_http = context.jsonrpc();
 
     // Get checkpoints when contract is empty
     let subnet_client = topos_sequencer_subnet_client::SubnetClient::new(
-        &subnet_jsonrpc_endpoint,
+        &subnet_jsonrpc_http,
         Some(hex::decode(TEST_SECRET_ETHEREUM_KEY).unwrap()),
         &subnet_smart_contract_address,
     )
@@ -908,11 +908,11 @@ async fn test_subnet_id_call(
     let context = context_running_subnet_node.await;
     let subnet_smart_contract_address =
         "0x".to_string() + &hex::encode(context.i_topos_core.address());
-    let subnet_jsonrpc_endpoint = context.jsonrpc();
+    let subnet_jsonrpc_http = context.jsonrpc();
 
     // Create subnet client
     let subnet_client = topos_sequencer_subnet_client::SubnetClient::new(
-        &subnet_jsonrpc_endpoint,
+        &subnet_jsonrpc_http,
         Some(hex::decode(TEST_SECRET_ETHEREUM_KEY).unwrap()),
         &subnet_smart_contract_address,
     )
@@ -954,7 +954,7 @@ async fn test_subnet_send_token_processing(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let context = context_running_subnet_node.await;
     let test_private_key = hex::decode(TEST_SECRET_ETHEREUM_KEY).unwrap();
-    let subnet_jsonrpc_endpoint = context.jsonrpc();
+    let subnet_jsonrpc_http = context.jsonrpc();
     let subnet_smart_contract_address =
         "0x".to_string() + &hex::encode(context.i_topos_core.address());
 
@@ -985,7 +985,7 @@ async fn test_subnet_send_token_processing(
     // Deploy token contract
     let i_erc20 = deploy_test_token(
         &hex::encode(&test_private_key),
-        &subnet_jsonrpc_endpoint,
+        &subnet_jsonrpc_http,
         context.i_topos_messaging.address(),
     )
     .await?;
@@ -1072,7 +1072,7 @@ async fn test_sync_from_genesis_and_particular_source_head(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let context = context_running_subnet_node.await;
     let test_private_key = hex::decode(TEST_SECRET_ETHEREUM_KEY).unwrap();
-    let subnet_jsonrpc_endpoint = context.jsonrpc();
+    let subnet_jsonrpc_http = context.jsonrpc();
     let subnet_smart_contract_address =
         "0x".to_string() + &hex::encode(context.i_topos_core.address());
 
@@ -1080,7 +1080,7 @@ async fn test_sync_from_genesis_and_particular_source_head(
     tokio::time::sleep(tokio::time::Duration::from_secs(10)).await;
 
     // Get block height
-    let http_provider = Provider::<Http>::try_from(subnet_jsonrpc_endpoint.clone())?
+    let http_provider = Provider::<Http>::try_from(subnet_jsonrpc_http.clone())?
         .interval(std::time::Duration::from_millis(20u64));
     let subnet_height = http_provider.get_block_number().await?.as_u64();
 
@@ -1148,7 +1148,7 @@ async fn test_sync_from_genesis_and_particular_source_head(
     //---------------------------------------------------------------------
     //
     // Get block height
-    let http_provider = Provider::<Http>::try_from(subnet_jsonrpc_endpoint)?
+    let http_provider = Provider::<Http>::try_from(subnet_jsonrpc_http)?
         .interval(std::time::Duration::from_millis(20u64));
     let subnet_height = http_provider.get_block_number().await?.as_u64();
     const SYNC_START_BLOCK_NUMBER: u64 = 11;
@@ -1235,7 +1235,7 @@ async fn test_sync_from_start_block(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let context = context_running_subnet_node.await;
     let test_private_key = hex::decode(TEST_SECRET_ETHEREUM_KEY).unwrap();
-    let subnet_jsonrpc_endpoint = context.jsonrpc();
+    let subnet_jsonrpc_http = context.jsonrpc();
     let subnet_smart_contract_address =
         "0x".to_string() + &hex::encode(context.i_topos_core.address());
 
@@ -1243,7 +1243,7 @@ async fn test_sync_from_start_block(
     tokio::time::sleep(tokio::time::Duration::from_secs(10)).await;
 
     // Get block height
-    let http_provider = Provider::<Http>::try_from(subnet_jsonrpc_endpoint.clone())?
+    let http_provider = Provider::<Http>::try_from(subnet_jsonrpc_http.clone())?
         .interval(std::time::Duration::from_millis(20u64));
     let subnet_height = http_provider.get_block_number().await?.as_u64();
 
@@ -1332,7 +1332,7 @@ async fn test_subnet_multiple_send_token_in_a_block(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let context = context_running_subnet_node.await;
     let test_private_key = hex::decode(TEST_SECRET_ETHEREUM_KEY).unwrap();
-    let subnet_jsonrpc_endpoint = context.jsonrpc();
+    let subnet_jsonrpc_http = context.jsonrpc();
     let subnet_smart_contract_address =
         "0x".to_string() + &hex::encode(context.i_topos_core.address());
     let number_of_send_token_transactions: usize = 4;
@@ -1366,7 +1366,7 @@ async fn test_subnet_multiple_send_token_in_a_block(
     // Deploy token contract
     let i_erc20 = deploy_test_token(
         &hex::encode(&test_private_key),
-        &subnet_jsonrpc_endpoint,
+        &subnet_jsonrpc_http,
         context.i_topos_messaging.address(),
     )
     .await?;
@@ -1409,28 +1409,28 @@ async fn test_subnet_multiple_send_token_in_a_block(
     let mut erc20_clients = vec![
         create_new_erc20_client(
             TEST_SECRET_ETHEREUM_KEY,
-            &subnet_jsonrpc_endpoint,
+            &subnet_jsonrpc_http,
             i_erc20.address(),
         )
         .await
         .expect("Valid erc20 client"),
         create_new_erc20_client(
             TEST_ACCOUNT_ALITH_KEY,
-            &subnet_jsonrpc_endpoint,
+            &subnet_jsonrpc_http,
             i_erc20.address(),
         )
         .await
         .expect("Valid erc20 client"),
         create_new_erc20_client(
             TEST_ACCOUNT_BALATHAR_KEY,
-            &subnet_jsonrpc_endpoint,
+            &subnet_jsonrpc_http,
             i_erc20.address(),
         )
         .await
         .expect("Valid erc20 client"),
         create_new_erc20_client(
             TEST_ACCOUNT_CEZAR_KEY,
-            &subnet_jsonrpc_endpoint,
+            &subnet_jsonrpc_http,
             i_erc20.address(),
         )
         .await
@@ -1460,7 +1460,7 @@ async fn test_subnet_multiple_send_token_in_a_block(
             TARGET_SUBNET_ID_5,
             create_new_erc20msg_client(
                 TEST_SECRET_ETHEREUM_KEY,
-                &subnet_jsonrpc_endpoint,
+                &subnet_jsonrpc_http,
                 context.i_erc20_messaging.address(),
             )
             .await
@@ -1470,7 +1470,7 @@ async fn test_subnet_multiple_send_token_in_a_block(
             TARGET_SUBNET_ID_4,
             create_new_erc20msg_client(
                 TEST_ACCOUNT_ALITH_KEY,
-                &subnet_jsonrpc_endpoint,
+                &subnet_jsonrpc_http,
                 context.i_erc20_messaging.address(),
             )
             .await
@@ -1480,7 +1480,7 @@ async fn test_subnet_multiple_send_token_in_a_block(
             TARGET_SUBNET_ID_3,
             create_new_erc20msg_client(
                 TEST_ACCOUNT_BALATHAR_KEY,
-                &subnet_jsonrpc_endpoint,
+                &subnet_jsonrpc_http,
                 context.i_erc20_messaging.address(),
             )
             .await
@@ -1490,7 +1490,7 @@ async fn test_subnet_multiple_send_token_in_a_block(
             TARGET_SUBNET_ID_2,
             create_new_erc20msg_client(
                 TEST_ACCOUNT_CEZAR_KEY,
-                &subnet_jsonrpc_endpoint,
+                &subnet_jsonrpc_http,
                 context.i_erc20_messaging.address(),
             )
             .await

--- a/crates/topos-sequencer/src/lib.rs
+++ b/crates/topos-sequencer/src/lib.rs
@@ -20,8 +20,8 @@ mod app_context;
 pub struct SequencerConfiguration {
     pub subnet_id: Option<String>,
     pub public_key: Option<Vec<u8>>,
-    pub subnet_jsonrpc_endpoint: String,
-    pub subnet_websocket_endpoint: Option<String>,
+    pub subnet_jsonrpc_http: String,
+    pub subnet_jsonrpc_ws: Option<String>,
     pub subnet_contract_address: String,
     pub tce_grpc_endpoint: String,
     pub signing_key: SecretKey,
@@ -51,7 +51,7 @@ pub async fn launch(
     // It will retry using backoff algorithm, but if it fails (default max backoff elapsed time is 15 min) we can not proceed
     else {
         let http_endpoint =
-            topos_sequencer_subnet_runtime::derive_endpoints(&config.subnet_jsonrpc_endpoint)
+            topos_sequencer_subnet_runtime::derive_endpoints(&config.subnet_jsonrpc_http)
                 .map_err(|e| {
                     Box::new(std::io::Error::new(
                         InvalidInput,
@@ -76,9 +76,9 @@ pub async fn launch(
     };
 
     let (http_endpoint, mut ws_endpoint) =
-        topos_sequencer_subnet_runtime::derive_endpoints(&config.subnet_jsonrpc_endpoint)?;
+        topos_sequencer_subnet_runtime::derive_endpoints(&config.subnet_jsonrpc_http)?;
 
-    if let Some(config_ws_endpoint) = config.subnet_websocket_endpoint.as_ref() {
+    if let Some(config_ws_endpoint) = config.subnet_jsonrpc_ws.as_ref() {
         // Use explicitly provided websocket subnet endpoint
         ws_endpoint = config_ws_endpoint.clone();
     }

--- a/crates/topos-sequencer/src/lib.rs
+++ b/crates/topos-sequencer/src/lib.rs
@@ -21,6 +21,7 @@ pub struct SequencerConfiguration {
     pub subnet_id: Option<String>,
     pub public_key: Option<Vec<u8>>,
     pub subnet_jsonrpc_endpoint: String,
+    pub subnet_websocket_endpoint: Option<String>,
     pub subnet_contract_address: String,
     pub tce_grpc_endpoint: String,
     pub signing_key: SecretKey,
@@ -74,8 +75,13 @@ pub async fn launch(
         }
     };
 
-    let (http_endpoint, ws_endpoint) =
+    let (http_endpoint, mut ws_endpoint) =
         topos_sequencer_subnet_runtime::derive_endpoints(&config.subnet_jsonrpc_endpoint)?;
+
+    if let Some(config_ws_endpoint) = config.subnet_websocket_endpoint.as_ref() {
+        // Use explicitly provided websocket subnet endpoint
+        ws_endpoint = config_ws_endpoint.clone();
+    }
 
     // Instantiate subnet runtime proxy, handling interaction with subnet node
     let subnet_runtime_proxy_worker = match SubnetRuntimeProxyWorker::new(

--- a/crates/topos/src/components/node/services.rs
+++ b/crates/topos/src/components/node/services.rs
@@ -59,8 +59,8 @@ pub(crate) fn spawn_sequencer_process(
     let config = SequencerConfiguration {
         subnet_id: None,
         public_key: keys.validator_pubkey(),
-        subnet_jsonrpc_endpoint: config.subnet_jsonrpc_endpoint,
-        subnet_websocket_endpoint: config.subnet_websocket_endpoint,
+        subnet_jsonrpc_http: config.subnet_jsonrpc_http,
+        subnet_jsonrpc_ws: config.subnet_jsonrpc_ws,
         subnet_contract_address: config.subnet_contract_address,
         tce_grpc_endpoint: config.tce_grpc_endpoint,
         signing_key: keys.validator.clone().unwrap(),

--- a/crates/topos/src/components/node/services.rs
+++ b/crates/topos/src/components/node/services.rs
@@ -60,6 +60,7 @@ pub(crate) fn spawn_sequencer_process(
         subnet_id: None,
         public_key: keys.validator_pubkey(),
         subnet_jsonrpc_endpoint: config.subnet_jsonrpc_endpoint,
+        subnet_websocket_endpoint: config.subnet_websocket_endpoint,
         subnet_contract_address: config.subnet_contract_address,
         tce_grpc_endpoint: config.tce_grpc_endpoint,
         signing_key: keys.validator.clone().unwrap(),

--- a/crates/topos/src/components/sequencer/commands/run.rs
+++ b/crates/topos/src/components/sequencer/commands/run.rs
@@ -9,21 +9,22 @@ pub struct Run {
     #[clap(long, env = "TOPOS_LOCAL_SUBNET_ID")]
     pub subnet_id: Option<String>,
 
-    // Subnet endpoint in the form [ip address]:[port]
-    // Topos sequencer expects both websocket and http protocol available
-    // on this subnet endpoint
+    /// Subnet endpoint in the form [ip address]:[port]
+    /// Topos sequencer expects both websocket and http protocol available
+    /// on this subnet endpoint. If optional `subnet_jsonrpc_ws` is not provided websocket endpoint
+    /// will be deduced from this parameter.
     #[clap(
         long,
         default_value = "127.0.0.1:8545",
-        env = "SUBNET_JSONRPC_ENDPOINT"
+        env = "TOPOS_SUBNET_JSONRPC_HTTP"
     )]
-    pub subnet_jsonrpc_endpoint: String,
+    pub subnet_jsonrpc_http: String,
 
-    // Optional explicit websocket endpoint for the subnet jsonrpc api. If this parameter is not provided,
-    // it will be derived from the `subnet_jsonrpc_endpoint`.
-    // Full uri value is expected, e.g. `wss://arbitrum.infura.com/v3/ws/mykey` or `ws://127.0.0.1/ws`
-    #[clap(long, env = "SUBNET_WEBSOCKET_ENDPOINT")]
-    pub subnet_websocket_endpoint: Option<String>,
+    /// Optional explicit websocket endpoint for the subnet jsonrpc api. If this parameter is not provided,
+    /// it will be derived from the `subnet_jsonrpc_http`.
+    /// Full uri value is expected, e.g. `wss://arbitrum.infura.com/v3/ws/mykey` or `ws://127.0.0.1/ws`
+    #[clap(long, env = "TOPOS_SUBNET_JSONRPC_WS")]
+    pub subnet_jsonrpc_ws: Option<String>,
 
     // Core contract address
     #[clap(long, env = "SUBNET_CONTRACT_ADDRESS")]

--- a/crates/topos/src/components/sequencer/commands/run.rs
+++ b/crates/topos/src/components/sequencer/commands/run.rs
@@ -19,6 +19,12 @@ pub struct Run {
     )]
     pub subnet_jsonrpc_endpoint: String,
 
+    // Optional explicit websocket endpoint for the subnet jsonrpc api. If this parameter is not provided,
+    // it will be derived from the `subnet_jsonrpc_endpoint`.
+    // Full uri value is expected, e.g. `wss://arbitrum.infura.com/v3/ws/mykey` or `ws://127.0.0.1/ws`
+    #[clap(long, env = "SUBNET_WEBSOCKET_ENDPOINT")]
+    pub subnet_websocket_endpoint: Option<String>,
+
     // Core contract address
     #[clap(long, env = "SUBNET_CONTRACT_ADDRESS")]
     pub subnet_contract_address: String,

--- a/crates/topos/src/components/sequencer/mod.rs
+++ b/crates/topos/src/components/sequencer/mod.rs
@@ -22,6 +22,7 @@ pub(crate) async fn handle_command(
                 subnet_id: cmd.subnet_id,
                 public_key: None,
                 subnet_jsonrpc_endpoint: cmd.subnet_jsonrpc_endpoint,
+                subnet_websocket_endpoint: cmd.subnet_websocket_endpoint,
                 subnet_contract_address: cmd.subnet_contract_address,
                 tce_grpc_endpoint: cmd.base_tce_api_url,
                 signing_key: keys.validator.clone().unwrap(),

--- a/crates/topos/src/components/sequencer/mod.rs
+++ b/crates/topos/src/components/sequencer/mod.rs
@@ -21,8 +21,8 @@ pub(crate) async fn handle_command(
             let config = SequencerConfiguration {
                 subnet_id: cmd.subnet_id,
                 public_key: None,
-                subnet_jsonrpc_endpoint: cmd.subnet_jsonrpc_endpoint,
-                subnet_websocket_endpoint: cmd.subnet_websocket_endpoint,
+                subnet_jsonrpc_http: cmd.subnet_jsonrpc_http,
+                subnet_jsonrpc_ws: cmd.subnet_jsonrpc_ws,
                 subnet_contract_address: cmd.subnet_contract_address,
                 tce_grpc_endpoint: cmd.base_tce_api_url,
                 signing_key: keys.validator.clone().unwrap(),

--- a/crates/topos/src/config/sequencer.rs
+++ b/crates/topos/src/config/sequencer.rs
@@ -19,6 +19,11 @@ pub struct SequencerConfig {
     #[serde(default = "default_subnet_jsonrpc_endpoint")]
     pub subnet_jsonrpc_endpoint: String,
 
+    // Optional explicit websocket endpoint for the subnet jsonrpc api. If this parameter is not provided,
+    // it will be derived from the `subnet_jsonrpc_endpoint`.
+    // Full uri value is expected, e.g. `wss://arbitrum.infura.com/v3/ws/mykey` or `ws://127.0.0.1/ws`
+    pub subnet_websocket_endpoint: Option<String>,
+
     /// Address where the Topos Core contract is deployed
     #[serde(default = "default_subnet_contract_address")]
     pub subnet_contract_address: String,

--- a/crates/topos/src/config/sequencer.rs
+++ b/crates/topos/src/config/sequencer.rs
@@ -17,12 +17,12 @@ pub struct SequencerConfig {
     /// JSON-RPC endpoint of the Edge node, websocket and http support expected
     /// If the endpoint address starts with `https`, ssl will be used with http/websocket
     #[serde(default = "default_subnet_jsonrpc_endpoint")]
-    pub subnet_jsonrpc_endpoint: String,
+    pub subnet_jsonrpc_http: String,
 
     // Optional explicit websocket endpoint for the subnet jsonrpc api. If this parameter is not provided,
-    // it will be derived from the `subnet_jsonrpc_endpoint`.
+    // it will be derived from the `subnet_jsonrpc_http`.
     // Full uri value is expected, e.g. `wss://arbitrum.infura.com/v3/ws/mykey` or `ws://127.0.0.1/ws`
-    pub subnet_websocket_endpoint: Option<String>,
+    pub subnet_jsonrpc_ws: Option<String>,
 
     /// Address where the Topos Core contract is deployed
     #[serde(default = "default_subnet_contract_address")]

--- a/crates/topos/tests/snapshots/sequencer__sequencer_help_display.snap
+++ b/crates/topos/tests/snapshots/sequencer__sequencer_help_display.snap
@@ -13,8 +13,10 @@ Options:
           Defines the verbosity level
       --home <HOME>
           Home directory for the configuration [env: TOPOS_HOME=] [default: /home/runner/.config/topos]
-      --subnet-jsonrpc-endpoint <SUBNET_JSONRPC_ENDPOINT>
-          [env: SUBNET_JSONRPC_ENDPOINT=] [default: 127.0.0.1:8545]
+      --subnet-jsonrpc-http <SUBNET_JSONRPC_HTTP>
+          Subnet endpoint in the form [ip address]:[port] Topos sequencer expects both websocket and http protocol available on this subnet endpoint. If optional `subnet_jsonrpc_ws` is not provided websocket endpoint will be deduced from this parameter [env: TOPOS_SUBNET_JSONRPC_HTTP=] [default: 127.0.0.1:8545]
+      --subnet-jsonrpc-ws <SUBNET_JSONRPC_WS>
+          Optional explicit websocket endpoint for the subnet jsonrpc api. If this parameter is not provided, it will be derived from the `subnet_jsonrpc_http`. Full uri value is expected, e.g. `wss://arbitrum.infura.com/v3/ws/mykey` or `ws://127.0.0.1/ws` [env: TOPOS_SUBNET_JSONRPC_WS=]
       --subnet-contract-address <SUBNET_CONTRACT_ADDRESS>
           [env: SUBNET_CONTRACT_ADDRESS=]
       --base-tce-api-url <BASE_TCE_API_URL>


### PR DESCRIPTION
# Description

Add sequencer command line argument `--subnet-websocket-endpoint` to explicitly provided subnet jsonrpc websocket endpoint. Usable when subnet endpoint could not be derived from ` http/https` endpoint in a standard way (what is done by default), e.g. when custom cloud websocket endpoints are used.

Fixes TP-749


## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
