### PR TITLE
fix: add default features for docker workflow

### DIFF
--- a/.github/workflows/docker_utils.yml
+++ b/.github/workflows/docker_utils.yml
@@ -1,7 +1,7 @@
 name: template - docker
 
 env:
-  DEFAULT_FEATURES: tce,sequencer
+  DEFAULT_FEATURES: tce,sequencer,node,subnet
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
   AWS_SHARED_CREDENTIALS_FILE: "${{ github.workspace }}/.aws/credentials"
@@ -22,7 +22,7 @@ on:
       features:
         required: false
         type: string
-        default: tce,sequencer,network
+        default: tce,sequencer,network, node, subnet
     outputs:
       tags:
         description: "Docker tags"

--- a/.github/workflows/docker_utils.yml
+++ b/.github/workflows/docker_utils.yml
@@ -22,7 +22,7 @@ on:
       features:
         required: false
         type: string
-        default: tce,sequencer,network, node, subnet
+        default: tce,sequencer,network,node,subnet
     outputs:
       tags:
         description: "Docker tags"


### PR DESCRIPTION
# Description

Adding the default features `subnet` and `node` to be able to deploy the latest state of `topos`.

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
