### PR TITLE
chore: remove unused deps on broadcast crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7710,7 +7710,6 @@ dependencies = [
  "topos-core",
  "topos-crypto",
  "topos-metrics",
- "topos-p2p",
  "topos-tce-storage",
  "topos-tce-transport",
  "topos-test-sdk",

--- a/crates/topos-tce-broadcast/Cargo.toml
+++ b/crates/topos-tce-broadcast/Cargo.toml
@@ -20,7 +20,6 @@ tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }
 tracing.workspace = true
 tce_transport = { package = "topos-tce-transport", path = "../topos-tce-transport"}
 topos-core = { workspace = true, features = ["uci"] }
-topos-p2p = { path = "../topos-p2p/"}
 topos-metrics = { path = "../topos-metrics/" }
 topos-tce-storage = { path = "../topos-tce-storage/" }
 topos-crypto = { path = "../topos-crypto" }


### PR DESCRIPTION
# Description

This PR is just removing unused dependencies on `topos-tce-broadcast` crate.

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/topos-protocol/topos/assets/1394604/711f85e4-ea0c-4888-a599-365ddb2b8889">
  <img alt="Text changing depending on mode. Light: 'So light!' Dark: 'So dark!'" src="https://github.com/topos-protocol/topos/assets/1394604/363016ed-70d6-48a4-b7d7-0829903ef4fa">
</picture>


## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
