### PR TITLE
fix: adjust graphql port in docker setup

### DIFF
--- a/tools/docker-compose.yml
+++ b/tools/docker-compose.yml
@@ -50,7 +50,7 @@ services:
       - "9090"
       - "1340:1340"
       - "3000:3000"
-      - "4000:4000"
+      - "4030:4030"
     env_file:
       - env/base.env
       - env/node.env
@@ -87,7 +87,7 @@ services:
       - "9090"
       - "1340"
       - "3000"
-      - "4000"
+      - "4030"
     deploy:
       replicas: 14
     env_file:
@@ -121,7 +121,7 @@ services:
       - "9090"
       - "1340"
       - "3000"
-      - "4000"
+      - "4030"
     env_file:
       - env/base.env
       - env/node.env


### PR DESCRIPTION
# Description

The `GraphQL` port in the docker setup was outdated and therefore couldn't access the `GraphQL` playground anymore.

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
