### PR TITLE
fix: add kebab-case rewrite for init and up commands

### DIFF
--- a/crates/topos/src/components/node/commands/init.rs
+++ b/crates/topos/src/components/node/commands/init.rs
@@ -15,8 +15,8 @@ pub struct Init {
     pub role: NodeRole,
 
     /// Subnet of your node
-    #[arg(long, env = "TOPOS_NODE_SUBNET_ID", default_value = "topos")]
-    pub subnet_id: Option<String>,
+    #[arg(long, env = "TOPOS_NODE_SUBNET", default_value = "topos")]
+    pub subnet: Option<String>,
 
     /// The path to the SecretsManager config file. Used for Hashicorp Vault.
     /// If omitted, the local FS secrets manager is used

--- a/crates/topos/src/components/node/commands/init.rs
+++ b/crates/topos/src/components/node/commands/init.rs
@@ -4,6 +4,7 @@ use serde::Serialize;
 
 #[derive(Args, Debug, Serialize)]
 #[command(about = "Setup your node!", trailing_var_arg = true)]
+#[serde(rename_all = "kebab-case")]
 pub struct Init {
     /// Name to identify your node
     #[arg(long, env = "TOPOS_NODE_NAME", default_value = "default")]
@@ -14,7 +15,7 @@ pub struct Init {
     pub role: NodeRole,
 
     /// Subnet of your node
-    #[arg(long, env = "TOPOS_NODE_SUBNET", default_value = "topos")]
+    #[arg(long, env = "TOPOS_NODE_SUBNET_ID", default_value = "topos")]
     pub subnet_id: Option<String>,
 
     /// The path to the SecretsManager config file. Used for Hashicorp Vault.

--- a/crates/topos/src/components/node/commands/init.rs
+++ b/crates/topos/src/components/node/commands/init.rs
@@ -15,7 +15,7 @@ pub struct Init {
 
     /// Subnet of your node
     #[arg(long, env = "TOPOS_NODE_SUBNET", default_value = "topos")]
-    pub subnet: Option<String>,
+    pub subnet_id: Option<String>,
 
     /// The path to the SecretsManager config file. Used for Hashicorp Vault.
     /// If omitted, the local FS secrets manager is used

--- a/crates/topos/src/components/node/commands/up.rs
+++ b/crates/topos/src/components/node/commands/up.rs
@@ -3,6 +3,7 @@ use serde::Serialize;
 
 #[derive(Args, Debug, Serialize)]
 #[command(about = "Spawn your node!")]
+#[serde(rename_all = "kebab-case")]
 pub struct Up {
     /// Name to identify your node
     #[arg(long, env = "TOPOS_NODE_NAME", default_value = "default")]

--- a/crates/topos/src/config/base.rs
+++ b/crates/topos/src/config/base.rs
@@ -11,6 +11,7 @@ use crate::config::node::NodeRole;
 use crate::config::Config;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "kebab-case")]
 pub struct BaseConfig {
     #[serde(default = "default_name")]
     pub name: String,

--- a/crates/topos/src/config/base.rs
+++ b/crates/topos/src/config/base.rs
@@ -11,7 +11,6 @@ use crate::config::node::NodeRole;
 use crate::config::Config;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-#[serde(rename_all = "kebab-case")]
 pub struct BaseConfig {
     #[serde(default = "default_name")]
     pub name: String,
@@ -19,7 +18,7 @@ pub struct BaseConfig {
     #[serde(default = "default_role")]
     pub role: NodeRole,
 
-    #[serde(default = "default_subnet")]
+    #[serde(default = "default_subnet_id")]
     pub subnet_id: String,
 
     #[serde(default = "default_secrets_config")]
@@ -34,7 +33,7 @@ fn default_role() -> NodeRole {
     NodeRole::Validator
 }
 
-fn default_subnet() -> String {
+fn default_subnet_id() -> String {
     "topos".to_string()
 }
 

--- a/crates/topos/src/config/base.rs
+++ b/crates/topos/src/config/base.rs
@@ -19,7 +19,7 @@ pub struct BaseConfig {
     #[serde(default = "default_role")]
     pub role: NodeRole,
 
-    #[serde(default = "default_subnet_id")]
+    #[serde(default = "default_subnet")]
     pub subnet_id: String,
 
     #[serde(default = "default_secrets_config")]
@@ -34,7 +34,7 @@ fn default_role() -> NodeRole {
     NodeRole::Validator
 }
 
-fn default_subnet_id() -> String {
+fn default_subnet() -> String {
     "topos".to_string()
 }
 


### PR DESCRIPTION
# Description

Fixed an issue where CLI arguments from the `node init` command where not taken due to auto-rewriting of `kebab-case`.


- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
