### PR TITLE
fix: sequencer catch up mechanism

### DIFF
--- a/crates/topos-sequencer-subnet-client/src/lib.rs
+++ b/crates/topos-sequencer-subnet-client/src/lib.rs
@@ -132,21 +132,6 @@ impl SubnetClientListener {
         &mut self,
         next_block_number: u64,
     ) -> Result<BlockInfo, Error> {
-        let latest_subnet_block_number = self
-            .provider
-            .get_block_number()
-            .await
-            .map_err(Error::EthersProviderError)?;
-
-        info!(
-            "Finalized block number: next={} and latest={}",
-            next_block_number, latest_subnet_block_number
-        );
-
-        if latest_subnet_block_number.as_u64() < next_block_number {
-            return Err(Error::BlockNotAvailable(next_block_number));
-        }
-
         let block = self
             .provider
             .get_block(next_block_number)

--- a/crates/topos-sequencer-subnet-runtime/src/proxy.rs
+++ b/crates/topos-sequencer-subnet-runtime/src/proxy.rs
@@ -226,6 +226,7 @@ impl SubnetRuntimeProxy {
 
                 // Go to standard mode of listening for new blocks
                 let mut interval = time::interval(SUBNET_BLOCK_TIME);
+                interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
                 let shutdowned: Option<oneshot::Sender<()>> = 'tick_loop: loop {
                     tokio::select! {
                         _ = interval.tick() => {


### PR DESCRIPTION
# Description

Fix block retrieval with timer. On every timer tick catch up with the latest block. Delay timer if catching up takes more time than one tick.

Fixes TP-783

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
