### PR TITLE
feat: use websocket stream block listener

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ tower = "0.4"
 ethereum-types = { version = "0.13.1"}
 secp256k1 = {version = "0.27", features = ["recovery"]}
 tiny-keccak = {version = "1.5"}
-ethers = {version = "2.0.4", features = ["legacy", "abigen-online"]}
+ethers = {version = "2.0.9", features = ["legacy", "abigen-online"]}
 
 # Log, Tracing & telemetry
 opentelemetry = { version = "0.19", features = ["rt-tokio", "metrics"] }

--- a/crates/topos-sequencer-subnet-client/src/lib.rs
+++ b/crates/topos-sequencer-subnet-client/src/lib.rs
@@ -57,12 +57,12 @@ pub struct BlockInfo {
 pub enum Error {
     #[error("new finalized block not available")]
     BlockNotAvailable(u64),
-    #[error("next stream block not available")]
+    #[error("next stream block is not available")]
     StreamBlockNotAvailable,
     #[error("invalid block number: {0}")]
     InvalidBlockNumber(u64),
-    #[error("data not available")]
-    DataNotAvailable,
+    #[error("block number not available")]
+    BlockNumberNotAvailable,
     #[error("failed mutable cast")]
     MutableCastFailed,
     #[error("json error: {source}")]
@@ -211,7 +211,7 @@ impl SubnetClientListener {
         stream: &mut SubscriptionStream<'_, Ws, ethers::types::Block<ethers::types::H256>>,
     ) -> Result<BlockInfo, Error> {
         if let Some(block) = stream.next().await {
-            let block_number = block.number.ok_or(Error::DataNotAvailable)?;
+            let block_number = block.number.ok_or(Error::BlockNumberNotAvailable)?;
             let events = match get_block_events(&self.contract, block_number).await {
                 Ok(events) => events,
                 Err(Error::EventDecodingError(e)) => {

--- a/crates/topos-sequencer-subnet-client/src/lib.rs
+++ b/crates/topos-sequencer-subnet-client/src/lib.rs
@@ -171,7 +171,11 @@ impl SubnetClientListener {
             Ok(events) => events,
             Err(Error::EventDecodingError(e)) => {
                 // FIXME: Happens in block before subnet contract is deployed, seems like bug in ethers
-                error!("Unable to parse events from block {}: {e}", block_number);
+                error!(
+                    "Error decoding events from block {}: {e} \nTopos smart contracts may not be \
+                     deployed?",
+                    block_number
+                );
                 Vec::new()
             }
             Err(e) => {
@@ -216,7 +220,11 @@ impl SubnetClientListener {
                 Ok(events) => events,
                 Err(Error::EventDecodingError(e)) => {
                     // FIXME: Happens in block before subnet contract is deployed, seems like bug in ethers
-                    error!("Unable to parse events from block {}: {e}", block_number);
+                    error!(
+                        "Error decoding events from block {}: {e} \nTopos smart contracts may not \
+                         be deployed?",
+                        block_number
+                    );
                     Vec::new()
                 }
                 Err(e) => {

--- a/crates/topos-sequencer-subnet-runtime/src/proxy.rs
+++ b/crates/topos-sequencer-subnet-runtime/src/proxy.rs
@@ -8,7 +8,7 @@ use std::fmt::{Debug, Formatter};
 use std::sync::Arc;
 use tokio::sync::Mutex;
 use tokio::sync::{mpsc, oneshot};
-use tokio::time::{self, Duration};
+use tokio::time::Duration;
 use topos_core::api::grpc::checkpoints::TargetStreamPosition;
 use topos_core::uci::{Certificate, CertificateId, SubnetId};
 use topos_sequencer_subnet_client::{self, BlockInfo, SubnetClient, SubnetClientListener};
@@ -250,7 +250,6 @@ impl SubnetRuntimeProxy {
                                         error!("Failed to process next block: {}", e);
                                         break None;
                                     }
-                                    latest_acquired_subnet_block_number = new_block_number;
                                 }
                                 Err(e) => {
                                     error!("Failed to retrieve next block: {}, trying again soon", e);

--- a/crates/topos-sequencer-subnet-runtime/src/proxy.rs
+++ b/crates/topos-sequencer-subnet-runtime/src/proxy.rs
@@ -253,6 +253,7 @@ impl SubnetRuntimeProxy {
                                 }
                                 Err(e) => {
                                     error!("Failed to retrieve next block: {}, trying again soon", e);
+                                    tokio::time::sleep(Duration::from_millis(1000)).await;
                                     continue;
                                 }
                             }

--- a/crates/topos-sequencer-subnet-runtime/src/proxy.rs
+++ b/crates/topos-sequencer-subnet-runtime/src/proxy.rs
@@ -374,13 +374,7 @@ impl SubnetRuntimeProxy {
         // Update certificate block history
         certification.append_blocks(vec![block_info]);
 
-        let new_certificates = match certification.generate_certificates().await {
-            Ok(certificates) => certificates,
-            Err(e) => {
-                error!("Unable to generate certificates: {e}");
-                return Err(e);
-            }
-        };
+        let new_certificates = certification.generate_certificates().await?;
 
         debug!("Generated new certificates {new_certificates:?}");
 

--- a/crates/topos-sequencer-subnet-runtime/src/proxy.rs
+++ b/crates/topos-sequencer-subnet-runtime/src/proxy.rs
@@ -11,12 +11,9 @@ use tokio::sync::{mpsc, oneshot};
 use tokio::time::{self, Duration};
 use topos_core::api::grpc::checkpoints::TargetStreamPosition;
 use topos_core::uci::{Certificate, CertificateId, SubnetId};
-use topos_sequencer_subnet_client::{self, SubnetClient, SubnetClientListener};
+use topos_sequencer_subnet_client::{self, BlockInfo, SubnetClient, SubnetClientListener};
 use tracing::{debug, error, field, info, info_span, instrument, warn, Instrument, Span};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
-
-/// Arbitrary tick duration for fetching new finalized blocks
-const SUBNET_BLOCK_TIME: Duration = Duration::new(2, 0);
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Authorities {
@@ -205,7 +202,7 @@ impl SubnetRuntimeProxy {
                     while latest_acquired_subnet_block_number < current_subnet_block_number {
                         let next_block_number = latest_acquired_subnet_block_number + 1;
                         info!("Retrieving historical block {}", next_block_number);
-                        if let Err(e) = SubnetRuntimeProxy::process_next_block(
+                        if let Err(e) = SubnetRuntimeProxy::retrieve_and_process_block(
                             runtime_proxy.clone(),
                             &mut subnet_listener,
                             certification.clone(),
@@ -223,30 +220,44 @@ impl SubnetRuntimeProxy {
                     }
                 }
 
+                // Create a new subscription stream to listen for new blocks from subnet node
+                let mut subscription_stream =
+                    match subnet_listener.new_block_subscription_stream().await {
+                        Ok(stream) => stream,
+                        Err(e) => {
+                            panic!(
+                                "Failed to open subnet node block subscription stream, unable to \
+                                 proceed with certificate generation: {e}"
+                            )
+                        }
+                    };
+
+                info!("Block subscription stream opened, listening for new blocks...");
+
                 // Go to standard mode of listening for new blocks
-                let mut interval = time::interval(SUBNET_BLOCK_TIME);
                 let shutdowned: Option<oneshot::Sender<()>> = loop {
                     tokio::select! {
-                        _ = interval.tick() => {
-                            let next_block_number = latest_acquired_subnet_block_number + 1;
-                            if let Err(e) = SubnetRuntimeProxy::process_next_block(
-                                runtime_proxy.clone(),
-                                &mut subnet_listener,
-                                certification.clone(),
-                                next_block_number as u64
-                            ).await {
-                                match e {
-                                    Error::SubnetError { source: topos_sequencer_subnet_client::Error::BlockNotAvailable(_) } => {
-                                        continue;
-                                    }
-                                    _ => {
+                        result = subnet_listener.wait_for_new_block(&mut subscription_stream) => {
+                            match result {
+                                Ok(block) => {
+                                    let new_block_number = block.number as i128;
+                                    info!("Successfully received new block {} from the subnet subscription", new_block_number);
+                                    if let Err(e) = SubnetRuntimeProxy::process_block(
+                                        runtime_proxy.clone(),
+                                        certification.clone(),
+                                        block
+                                    ).await {
                                         error!("Failed to process next block: {}", e);
                                         break None;
                                     }
+                                    latest_acquired_subnet_block_number = new_block_number;
+                                }
+                                Err(e) => {
+                                    error!("Failed to retrieve next block: {}, trying again soon", e);
+                                    continue;
                                 }
                             }
-                            latest_acquired_subnet_block_number = next_block_number;
-                        },
+                        }
                         shutdown = block_task_shutdown.recv() => {
                             break shutdown;
                         }
@@ -303,7 +314,7 @@ impl SubnetRuntimeProxy {
         Ok(runtime_proxy)
     }
 
-    async fn process_next_block(
+    async fn retrieve_and_process_block(
         subnet_runtime_proxy: Arc<Mutex<SubnetRuntimeProxy>>,
         subnet_listener: &mut SubnetClientListener,
         certification: Arc<Mutex<Certification>>,
@@ -350,6 +361,34 @@ impl SubnetRuntimeProxy {
                 Err(Error::SubnetError { source: e })
             }
         }
+    }
+
+    async fn process_block(
+        subnet_runtime_proxy: Arc<Mutex<SubnetRuntimeProxy>>,
+        certification: Arc<Mutex<Certification>>,
+        block_info: BlockInfo,
+    ) -> Result<(), Error> {
+        let mut certification = certification.lock().await;
+        let block_number = block_info.number;
+
+        // Update certificate block history
+        certification.append_blocks(vec![block_info]);
+
+        let new_certificates = match certification.generate_certificates().await {
+            Ok(certificates) => certificates,
+            Err(e) => {
+                error!("Unable to generate certificates: {e}");
+                return Err(e);
+            }
+        };
+
+        debug!("Generated new certificates {new_certificates:?}");
+
+        for cert in new_certificates {
+            Self::send_new_certificate(subnet_runtime_proxy.clone(), cert, block_number).await
+        }
+        info!("Block {} processed", block_number);
+        Ok(())
     }
 
     /// Dispatch newly generated certificate to TCE client


### PR DESCRIPTION
# Description

Change block retrieval from the subnet node. Use websocket stream block subscription instead of timer. 

Fixes TP-599

## Additions and Changes

Old mechanism to retrieve block by number is kept for initial block sync on sequencer startup. When sync is performed, blocks are further received though block subscription stream.

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
