### PR TITLE
fix: change error to debug

### DIFF
--- a/crates/topos-tce-broadcast/src/double_echo/mod.rs
+++ b/crates/topos-tce-broadcast/src/double_echo/mod.rs
@@ -156,7 +156,7 @@ impl DoubleEcho {
                                 DoubleEchoCommand::Echo { certificate_id, validator_id, signature } => {
                                     // Check if source is part of known_validators
                                     if !self.validators.contains(&validator_id) {
-                                        return error!("ECHO message comes from non-validator: {}", validator_id);
+                                        return debug!("ECHO message comes from non-validator: {}", validator_id);
                                     }
 
                                     let mut payload = Vec::new();
@@ -164,7 +164,7 @@ impl DoubleEcho {
                                     payload.extend_from_slice(validator_id.as_bytes());
 
                                     if let Err(e) = self.message_signer.verify_signature(signature, &payload, validator_id.address()) {
-                                        return error!("ECHO messag signature cannot be verified from: {}", e);
+                                        return debug!("ECHO messag signature cannot be verified from: {}", e);
                                     }
 
                                     self.handle_echo(certificate_id, validator_id, signature).await
@@ -172,7 +172,7 @@ impl DoubleEcho {
                                 DoubleEchoCommand::Ready { certificate_id, validator_id, signature } => {
                                     // Check if source is part of known_validators
                                     if !self.validators.contains(&validator_id) {
-                                        return error!("READY message comes from non-validator: {}", validator_id);
+                                        return debug!("READY message comes from non-validator: {}", validator_id);
                                     }
 
                                     let mut payload = Vec::new();
@@ -180,7 +180,7 @@ impl DoubleEcho {
                                     payload.extend_from_slice(validator_id.as_bytes());
 
                                     if let Err(e) = self.message_signer.verify_signature(signature, &payload, validator_id.address()) {
-                                        return error!("READY message signature cannot be verified from: {}", e);
+                                        return debug!("READY message signature cannot be verified from: {}", e);
                                     }
 
                                     self.handle_ready(certificate_id, validator_id, signature).await


### PR DESCRIPTION
# Description

When a double echo message (`READY` | `ECHO`) is received from a non-validator (a node which is not part of the validator list), it's technically not an error. It's expected behaviour. So we change it to `debug` instead of `error` so we don't overcrowd our logs.

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
