### PR TITLE
chore: adding openssl as dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4714,9 +4714,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.57"
+version = "0.10.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bac25ee399abb46215765b1cb35bc0212377e58a061560d8b29b024fd0430e7c"
+checksum = "6b8419dc8cc6d866deb801274bba2e6f8f6108c1bb7fcc10ee5ab864931dbb45"
 dependencies = [
  "bitflags 2.4.1",
  "cfg-if",
@@ -4745,13 +4745,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
-name = "openssl-sys"
-version = "0.9.93"
+name = "openssl-src"
+version = "300.1.6+3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db4d56a4c0478783083cfafcc42493dd4a981d41669da64b4572a2a089b51b1d"
+checksum = "439fac53e092cd7442a3660c85dde4643ab3b5bd39040912388dcdabf6b88085"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.97"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3eaad34cdd97d81de97964fc7f29e2d104f483840d906ef56daa1912338460b"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -7345,6 +7355,7 @@ dependencies = [
  "insta",
  "libp2p",
  "once_cell",
+ "openssl",
  "opentelemetry",
  "opentelemetry-otlp",
  "predicates 3.0.4",

--- a/crates/topos/Cargo.toml
+++ b/crates/topos/Cargo.toml
@@ -46,6 +46,7 @@ once_cell = "1.17.1"
 toml = "0.7.4"
 regex = "1"
 rlp = "0.5.1"
+openssl = { version = "0.10.61", features = ["vendored"] }
 
 [dev-dependencies]
 topos-tce-broadcast = { path = "../topos-tce-broadcast" }


### PR DESCRIPTION
# Description

`openssl` need to be added as `vendored` to be able to build cross compilation binary

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
