### PR TITLE
feat: add no-edge-process flag to node init

### DIFF
--- a/crates/topos/src/components/node/commands/init.rs
+++ b/crates/topos/src/components/node/commands/init.rs
@@ -22,4 +22,9 @@ pub struct Init {
     /// If omitted, the local FS secrets manager is used
     #[arg(long, env = "TOPOS_SECRETS_MANAGER")]
     pub secrets_config: Option<String>,
+
+    /// For certain use cases, we manually provide private keys to a running node, and don't want to
+    /// rely on polygon-edge during runtime. Example: A sequencer which runs for an external EVM chain
+    #[arg(long, env = "TOPOS_NO_EDGE_PROCESS", action)]
+    pub no_edge_process: bool,
 }

--- a/crates/topos/src/components/node/mod.rs
+++ b/crates/topos/src/components/node/mod.rs
@@ -74,17 +74,21 @@ pub(crate) async fn handle_command(
             // Generate the configuration as per the role
             let mut config_toml = toml::Table::new();
 
-            // Generate the Edge configuration
-            if let Ok(result) = services::process::generate_edge_config(
-                edge_path.join(BINARY_NAME),
-                node_path.clone(),
-            )
-            .await
-            {
-                if result.is_err() {
-                    println!("Failed to generate edge config");
-                    remove_dir_all(node_path).expect("failed to remove config folder");
-                    std::process::exit(1);
+            if cmd.no_edge_process {
+                println!("Init the node without polygon-edge process...");
+            } else {
+                // Generate the Edge configuration
+                if let Ok(result) = services::process::generate_edge_config(
+                    edge_path.join(BINARY_NAME),
+                    node_path.clone(),
+                )
+                .await
+                {
+                    if result.is_err() {
+                        println!("Failed to generate edge config");
+                        remove_dir_all(node_path).expect("failed to remove config folder");
+                        std::process::exit(1);
+                    }
                 }
             }
 

--- a/crates/topos/tests/config.rs
+++ b/crates/topos/tests/config.rs
@@ -93,6 +93,38 @@ async fn handle_command_init() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
+#[tokio::test]
+async fn handle_command_init_without_polygon_edge() -> Result<(), Box<dyn std::error::Error>> {
+    let tmp_home_dir = tempdir()?;
+
+    let mut cmd = Command::cargo_bin("topos")?;
+    cmd.arg("node")
+        .arg("init")
+        .arg("--home")
+        .arg(tmp_home_dir.path().to_str().unwrap())
+        .arg("--no-edge-process");
+
+    let output = cmd.assert().success();
+    let result: &str = std::str::from_utf8(&output.get_output().stdout)?;
+
+    assert!(result.contains("Created node config file"));
+
+    let home = PathBuf::from(tmp_home_dir.path());
+
+    // Verification: check that the config file was created
+    let config_path = home.join("node").join("default").join("config.toml");
+    assert!(config_path.exists());
+
+    // Further verification might include checking the contents of the config file
+    let config_contents = std::fs::read_to_string(&config_path).unwrap();
+
+    assert!(config_contents.contains("[base]"));
+    assert!(config_contents.contains("name = \"default\""));
+    assert!(config_contents.contains("[tce]"));
+
+    Ok(())
+}
+
 #[test]
 fn nothing_written_if_failure() -> Result<(), Box<dyn std::error::Error>> {
     let tmp_home_dir = tempdir()?;


### PR DESCRIPTION
# Description

There are use cases for which we don't rely on `polygon-edge`. If we don't need it, we can run `node up --no-edge-process`. However, when creating a new `config` setup, we always assume `polygon-edge` is present. In the case of a `solo-sequencer`, we want to supply a fixed `validator.key` for example, and don't need or want `polygon-edge` in the process. 

Fixes [# (issue)](https://linear.app/toposware/issue/TP-817/give-the-option-to-run-node-init-without-polygon-edge)

### New feature 

Adding a `--no-edge-process` flag to `node init`.

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
