### PR TITLE
chore: adding no-color option to CLI

### DIFF
--- a/crates/topos/src/components/node/commands.rs
+++ b/crates/topos/src/components/node/commands.rs
@@ -24,6 +24,9 @@ pub(crate) struct NodeCommand {
     pub(crate) verbose: u8,
 
     #[clap(from_global)]
+    pub(crate) no_color: bool,
+
+    #[clap(from_global)]
     pub(crate) home: PathBuf,
 
     /// Installation directory path for Polygon Edge binary

--- a/crates/topos/src/components/node/mod.rs
+++ b/crates/topos/src/components/node/mod.rs
@@ -46,6 +46,7 @@ pub(crate) async fn handle_command(
     NodeCommand {
         subcommands,
         verbose,
+        no_color,
         home,
         edge_path,
     }: NodeCommand,
@@ -172,8 +173,12 @@ pub(crate) async fn handle_command(
 
             // Setup instrumentation if both otlp agent and otlp service name
             // are provided as arguments
-            let basic_controller =
-                setup_tracing(verbose, cmd_cloned.otlp_agent, cmd_cloned.otlp_service_name)?;
+            let basic_controller = setup_tracing(
+                verbose,
+                no_color,
+                cmd_cloned.otlp_agent,
+                cmd_cloned.otlp_service_name,
+            )?;
 
             let (shutdown_sender, shutdown_receiver) = mpsc::channel(1);
 

--- a/crates/topos/src/components/regtest/mod.rs
+++ b/crates/topos/src/components/regtest/mod.rs
@@ -22,7 +22,7 @@ pub(crate) async fn handle_command(
 ) -> Result<(), Box<dyn std::error::Error>> {
     match subcommands {
         Some(RegtestCommands::PushCertificate(cmd)) => {
-            _ = setup_tracing(verbose, None, None)?;
+            _ = setup_tracing(verbose, false, None, None)?;
             debug!("Start executing PushCertificate command");
             match services::push_certificate::check_delivery(
                 cmd.timeout_broadcast,
@@ -57,7 +57,8 @@ pub(crate) async fn handle_command(
 
             // Setup instrumentation if both otlp agent and otlp service name
             // are provided as arguments
-            let basic_controller = setup_tracing(verbose, cmd.otlp_agent, cmd.otlp_service_name)?;
+            let basic_controller =
+                setup_tracing(verbose, false, cmd.otlp_agent, cmd.otlp_service_name)?;
 
             let (shutdown_sender, shutdown_receiver) = mpsc::channel::<oneshot::Sender<()>>(1);
             let mut runtime = spawn(topos_certificate_spammer::run(config, shutdown_receiver));

--- a/crates/topos/src/options.rs
+++ b/crates/topos/src/options.rs
@@ -19,6 +19,7 @@ pub(crate) struct Opt {
     )]
     pub(crate) verbose: u8,
 
+    /// Disable color in logs
     #[arg(long, global = true, env = "TOPOS_LOG_NOCOLOR")]
     no_color: bool,
 

--- a/crates/topos/src/options.rs
+++ b/crates/topos/src/options.rs
@@ -19,6 +19,9 @@ pub(crate) struct Opt {
     )]
     pub(crate) verbose: u8,
 
+    #[arg(long, global = true, env = "TOPOS_LOG_NOCOLOR")]
+    no_color: bool,
+
     /// Home directory for the configuration
     #[arg(
         long,

--- a/crates/topos/src/tracing.rs
+++ b/crates/topos/src/tracing.rs
@@ -62,10 +62,13 @@ fn create_filter(verbose: u8) -> EnvFilter {
 // If otlp agent and otlp service name are provided, opentelemetry collection will be used
 pub(crate) fn setup_tracing(
     verbose: u8,
+    no_color: bool,
     otlp_agent: Option<String>,
     otlp_service_name: Option<String>,
 ) -> Result<Option<BasicController>, Box<dyn std::error::Error>> {
     let mut layers = Vec::new();
+
+    let ansi = !no_color;
 
     layers.push(
         match std::env::var("TOPOS_LOG_FORMAT")
@@ -75,14 +78,17 @@ pub(crate) fn setup_tracing(
         {
             Ok("json") => tracing_subscriber::fmt::layer()
                 .json()
+                .with_ansi(ansi)
                 .with_filter(create_filter(verbose))
                 .boxed(),
             Ok("pretty") => tracing_subscriber::fmt::layer()
                 .pretty()
+                .with_ansi(ansi)
                 .with_filter(create_filter(verbose))
                 .boxed(),
             _ => tracing_subscriber::fmt::layer()
                 .compact()
+                .with_ansi(ansi)
                 .with_filter(create_filter(verbose))
                 .boxed(),
         },

--- a/crates/topos/tests/snapshots/node__help_display.snap
+++ b/crates/topos/tests/snapshots/node__help_display.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/topos/tests/node.rs
-assertion_line: 16
 expression: "utils::sanitize_config_folder_path(result)"
 ---
 Utility to manage your nodes in the Topos network
@@ -16,6 +15,7 @@ Commands:
 Options:
       --edge-path <EDGE_PATH>  Installation directory path for Polygon Edge binary [env: TOPOS_POLYGON_EDGE_BIN_PATH=] [default: .]
   -v, --verbose...             Defines the verbosity level
+      --no-color               Disable color in logs [env: TOPOS_LOG_NOCOLOR=]
       --home <HOME>            Home directory for the configuration [env: TOPOS_HOME=] [default: /home/runner/.config/topos]
   -h, --help                   Print help
 

--- a/crates/topos/tests/snapshots/push_certificate__help_display.snap
+++ b/crates/topos/tests/snapshots/push_certificate__help_display.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/topos/tests/push-certificate.rs
-assertion_line: 19
 expression: "utils::sanitize_config_folder_path(result)"
 ---
 Push a certificate to a TCE process
@@ -12,10 +11,12 @@ Options:
           [default: plain] [possible values: json, plain]
   -v, --verbose...
           Defines the verbosity level
-      --home <HOME>
-          Home directory for the configuration [env: TOPOS_HOME=] [default: /home/runner/.config/topos]
+      --no-color
+          Disable color in logs [env: TOPOS_LOG_NOCOLOR=]
   -t, --timeout <TIMEOUT>
           Global timeout for the command [default: 60]
+      --home <HOME>
+          Home directory for the configuration [env: TOPOS_HOME=] [default: /home/runner/.config/topos]
       --timeout-broadcast <TIMEOUT_BROADCAST>
           Seconds to wait before asserting the broadcast [default: 30]
   -n, --nodes <NODES>

--- a/crates/topos/tests/snapshots/regtest__regtest_spam_help_display.snap
+++ b/crates/topos/tests/snapshots/regtest__regtest_spam_help_display.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/topos/tests/regtest.rs
-assertion_line: 16
 expression: "utils::sanitize_config_folder_path(result)"
 ---
 Run a test topos certificate spammer to send test certificates to the network, generating randomly among the `nb_subnets` subnets the batch of `cert_per_batch` certificates at every `batch-interval`
@@ -12,10 +11,12 @@ Options:
           The target node api endpoint. Multiple nodes could be specified as comma separated list e.g. `--target-nodes=http://[::1]:1340,http://[::1]:1341` [env: TOPOS_NETWORK_SPAMMER_TARGET_NODES=]
   -v, --verbose...
           Defines the verbosity level
-      --home <HOME>
-          Home directory for the configuration [env: TOPOS_HOME=] [default: /home/runner/.config/topos]
+      --no-color
+          Disable color in logs [env: TOPOS_LOG_NOCOLOR=]
       --target-nodes-path <TARGET_NODES_PATH>
           Path to json file with list of target nodes as alternative to `--target-nodes` [env: TOPOS_NETWORK_SPAMMER_TARGET_NODES_PATH=]
+      --home <HOME>
+          Home directory for the configuration [env: TOPOS_HOME=] [default: /home/runner/.config/topos]
       --local-key-seed <LOCAL_KEY_SEED>
           Seed for generation of local private signing keys and corresponding subnet ids [env: TOPOS_NETWORK_SPAMMER_LOCAL_KEY_SEED=] [default: 1]
       --cert-per-batch <CERT_PER_BATCH>


### PR DESCRIPTION
# Description

Add `--no-color` flag and `TOPOS_LOG_NOCOLOR` env var to disable color on the CLI

## PR Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
