### PR TITLE
chore: adding storage context on startup

### DIFF
--- a/crates/topos-tce-storage/src/fullnode/mod.rs
+++ b/crates/topos-tce-storage/src/fullnode/mod.rs
@@ -227,6 +227,10 @@ impl WriteStore for FullNodeStore {
 }
 
 impl ReadStore for FullNodeStore {
+    fn count_certificates_delivered(&self) -> Result<usize, StorageError> {
+        Ok(self.perpetual_tables.certificates.iter()?.count())
+    }
+
     fn get_source_head(&self, subnet_id: &SubnetId) -> Result<Option<SourceHead>, StorageError> {
         Ok(self
             .index_tables

--- a/crates/topos-tce-storage/src/store.rs
+++ b/crates/topos-tce-storage/src/store.rs
@@ -42,6 +42,9 @@ pub trait WriteStore: Send {
 /// [`ValidatorStore`](struct@super::validator::ValidatorStore) and
 /// [`FullNodeStore`](struct@super::fullnode::FullNodeStore) to read data.
 pub trait ReadStore: Send {
+    /// Returns the number of certificates delivered
+    fn count_certificates_delivered(&self) -> Result<usize, StorageError>;
+
     /// Try to get a SourceHead of a subnet
     ///
     /// Returns `Ok(None)` if the subnet is not found, meaning that no certificate are currently

--- a/crates/topos-tce-storage/src/validator/mod.rs
+++ b/crates/topos-tce-storage/src/validator/mod.rs
@@ -86,6 +86,11 @@ impl ValidatorStore {
         Ok(self.pending_tables.pending_pool.iter()?.count())
     }
 
+    /// Returns the number of certificates in the precedence pool
+    pub fn count_precedence_pool_certificates(&self) -> Result<usize, StorageError> {
+        Ok(self.pending_tables.precedence_pool.iter()?.count())
+    }
+
     /// Try to return the [`PendingCertificateId`] for a [`CertificateId`]
     ///
     /// Return `Ok(None)` if the `certificate_id` is not found.
@@ -375,6 +380,10 @@ impl ValidatorStore {
     }
 }
 impl ReadStore for ValidatorStore {
+    fn count_certificates_delivered(&self) -> Result<usize, StorageError> {
+        self.fullnode_store.count_certificates_delivered()
+    }
+
     fn get_source_head(&self, subnet_id: &SubnetId) -> Result<Option<SourceHead>, StorageError> {
         self.fullnode_store.get_source_head(subnet_id)
     }

--- a/crates/topos-tce/src/lib.rs
+++ b/crates/topos-tce/src/lib.rs
@@ -22,11 +22,12 @@ use topos_tce_storage::{
     epoch::{EpochValidatorsStore, ValidatorPerEpochStore},
     fullnode::FullNodeStore,
     index::IndexTables,
+    store::ReadStore,
     validator::{ValidatorPerpetualTables, ValidatorStore},
     StorageClient,
 };
 use topos_tce_synchronizer::SynchronizerService;
-use tracing::{debug, warn};
+use tracing::{debug, info, warn};
 
 mod app_context;
 pub mod config;
@@ -115,6 +116,24 @@ pub async fn run(
                 validator_store: validator_store.clone(),
             }),
         ),
+    );
+
+    let certificates_synced = fullnode_store
+        .count_certificates_delivered()
+        .expect("Unable to count certificates delivered");
+
+    let pending_certificates = validator_store
+        .count_pending_certificates()
+        .expect("Unable to count pending certificates");
+
+    let precedence_pool_certificates = validator_store
+        .count_precedence_pool_certificates()
+        .expect("Unable to count precedence pool certificates");
+
+    info!(
+        "Storage initialized with {} certificates delivered, {} pending certificates and {} \
+         certificates in the precedence pool",
+        certificates_synced, pending_certificates, precedence_pool_certificates
     );
 
     let (network_client, event_stream, unbootstrapped_runtime) = topos_p2p::network::builder()

--- a/crates/topos-tce/src/lib.rs
+++ b/crates/topos-tce/src/lib.rs
@@ -3,6 +3,7 @@ use futures::StreamExt;
 use opentelemetry::global;
 use std::{
     future::IntoFuture,
+    panic::UnwindSafe,
     sync::{atomic::AtomicBool, Arc},
 };
 use tokio::{
@@ -120,15 +121,18 @@ pub async fn run(
 
     let certificates_synced = fullnode_store
         .count_certificates_delivered()
-        .expect("Unable to count certificates delivered");
+        .map_err(|error| format!("Unable to count certificates delivered: {error}"))
+        .unwrap();
 
     let pending_certificates = validator_store
         .count_pending_certificates()
-        .expect("Unable to count pending certificates");
+        .map_err(|error| format!("Unable to count pending certificates: {error}"))
+        .unwrap();
 
     let precedence_pool_certificates = validator_store
         .count_precedence_pool_certificates()
-        .expect("Unable to count precedence pool certificates");
+        .map_err(|error| format!("Unable to count precedence pool certificates: {error}"))
+        .unwrap();
 
     info!(
         "Storage initialized with {} certificates delivered, {} pending certificates and {} \


### PR DESCRIPTION
# Description

This PR aims to add some extra context when node starts, mostly displaying the number of certificates synced, the pending/precedence pool certificates number.

```
INFO topos_tce: Storage initialized with 0 certificates delivered, 0 pending certificates and 0 certificates in the precedence pool
```
## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
