### PR TITLE
chore: remove audit ignore report

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,12 +1,2 @@
 [advisories]
-ignore = [
-    "RUSTSEC-2022-0061",
-    "RUSTSEC-2021-0139",
-
-    # Waiting for the libp2p-noise release bump to 0.43.1
-    # https://github.com/libp2p/rust-libp2p/pull/4358
-    "RUSTSEC-2022-0093",
-
-    # Waiting for webpki 0.22.0 to be fixed - no fixed upgrade is available!
-    "RUSTSEC-2023-0052",
-]
+ignore = []


### PR DESCRIPTION
# Description

Remove the previously ignored RUSTSEC:

- [RUSTSEC-2021-0139](https://rustsec.org/advisories/RUSTSEC-2021-0139.html)
- [RUSTSEC-2022-0061](https://rustsec.org/advisories/RUSTSEC-2022-0061.html)
- [RUSTSEC-2022-0093](https://rustsec.org/advisories/RUSTSEC-2022-0093)
- [RUSTSEC-2023-0052](https://rustsec.org/advisories/RUSTSEC-2023-0052.html)


## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
