### PR TITLE
chore: adding context to certificate broadcast

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -33,6 +33,7 @@ jobs:
 
       - name: Run tests
         env:
+          RUST_LOG: debug
           RUSTFLAGS: "-Cinstrument-coverage"
           RUSTDOCFLAGS: "-Cinstrument-coverage"
           LLVM_PROFILE_FILE: "codecov-instrumentation-%p-%m.profraw"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7626,6 +7626,7 @@ dependencies = [
  "bytes",
  "clap 4.4.6",
  "cucumber",
+ "env_logger 0.10.0",
  "futures",
  "hex",
  "hyper",

--- a/crates/topos-tce/Cargo.toml
+++ b/crates/topos-tce/Cargo.toml
@@ -59,6 +59,7 @@ tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }
 tracing.workspace = true
 test-log.workspace = true
 cucumber = "0.13.0"
+env_logger.workspace = true
 
 [features]
 default = []

--- a/crates/topos-tce/src/app_context/network.rs
+++ b/crates/topos-tce/src/app_context/network.rs
@@ -36,12 +36,11 @@ impl AppContext {
                         {
                             entry.insert(CERTIFICATE_DELIVERY_LATENCY.start_timer());
                         }
-
+                        debug!(
+                            "Received certificate {} from Gossip message from {}",
+                            cert.id, from
+                        );
                         spawn(async move {
-                            debug!(
-                                "Received certificate {} from Gossip message from {}",
-                                cert.id, from
-                            );
                             info!("Send certificate {} to be broadcast", cert.id);
                             if channel
                                 .send(DoubleEchoCommand::Broadcast {

--- a/crates/topos-tce/src/tests/api.rs
+++ b/crates/topos-tce/src/tests/api.rs
@@ -1,0 +1,107 @@
+use std::sync::Arc;
+
+use libp2p::PeerId;
+use prost::Message;
+use rstest::rstest;
+use test_log::test;
+use tokio::sync::{mpsc, oneshot};
+use topos_core::api::grpc::tce::v1::{double_echo_request, DoubleEchoRequest, Echo, Gossip, Ready};
+use topos_crypto::{messages::MessageSigner, validator_id::ValidatorId};
+use topos_tce_storage::{store::WriteStore, types::PendingResult};
+use topos_test_sdk::{
+    certificates::create_certificate_chain,
+    constants::{SOURCE_SUBNET_ID_1, TARGET_SUBNET_ID_1},
+};
+
+use crate::AppContext;
+
+use super::setup_test;
+
+#[rstest]
+#[test(tokio::test)]
+async fn handle_new_certificate(
+    #[future] setup_test: (
+        AppContext,
+        mpsc::Receiver<topos_p2p::Command>,
+        Arc<MessageSigner>,
+    ),
+) {
+    let (mut context, mut p2p_receiver, message_signer) = setup_test.await;
+    let mut certificates = create_certificate_chain(SOURCE_SUBNET_ID_1, &[TARGET_SUBNET_ID_1], 1);
+    let certificate = certificates.pop().unwrap().certificate;
+
+    let (sender, receiver) = oneshot::channel();
+
+    context
+        .on_api_event(topos_tce_api::RuntimeEvent::CertificateSubmitted {
+            certificate: Box::new(certificate),
+            sender,
+        })
+        .await;
+
+    let response = receiver.await;
+
+    assert!(matches!(response, Ok(Ok(PendingResult::InPending(_)))));
+}
+
+#[rstest]
+#[test(tokio::test)]
+async fn handle_certificate_in_precedence_pool(
+    #[future] setup_test: (
+        AppContext,
+        mpsc::Receiver<topos_p2p::Command>,
+        Arc<MessageSigner>,
+    ),
+) {
+    let (mut context, mut p2p_receiver, message_signer) = setup_test.await;
+    let mut certificates = create_certificate_chain(SOURCE_SUBNET_ID_1, &[TARGET_SUBNET_ID_1], 2);
+    let certificate = certificates.pop().unwrap().certificate;
+
+    let (sender, receiver) = oneshot::channel();
+
+    context
+        .on_api_event(topos_tce_api::RuntimeEvent::CertificateSubmitted {
+            certificate: Box::new(certificate),
+            sender,
+        })
+        .await;
+
+    let response = receiver.await;
+
+    assert!(matches!(response, Ok(Ok(PendingResult::AwaitPrecedence))));
+}
+
+#[rstest]
+#[test(tokio::test)]
+async fn handle_certificate_already_delivered(
+    #[future] setup_test: (
+        AppContext,
+        mpsc::Receiver<topos_p2p::Command>,
+        Arc<MessageSigner>,
+    ),
+) {
+    let (mut context, mut p2p_receiver, message_signer) = setup_test.await;
+    let mut certificates = create_certificate_chain(SOURCE_SUBNET_ID_1, &[TARGET_SUBNET_ID_1], 1);
+    let certificate_delivered = certificates.pop().unwrap();
+
+    _ = context
+        .validator_store
+        .insert_certificate_delivered(&certificate_delivered)
+        .await
+        .unwrap();
+
+    let certificate = certificate_delivered.certificate;
+
+    let (sender, receiver) = oneshot::channel();
+
+    context
+        .on_api_event(topos_tce_api::RuntimeEvent::CertificateSubmitted {
+            certificate: Box::new(certificate),
+            sender,
+        })
+        .await;
+
+    let response = receiver.await;
+
+    assert!(matches!(response, Ok(Ok(PendingResult::AlreadyDelivered))));
+}

--- a/crates/topos-tce/src/tests/mod.rs
+++ b/crates/topos-tce/src/tests/mod.rs
@@ -25,6 +25,9 @@ use topos_test_sdk::{
 
 use crate::AppContext;
 
+mod api;
+mod network;
+
 #[rstest]
 #[tokio::test]
 async fn non_validator_publish_gossip(
@@ -91,7 +94,7 @@ async fn non_validator_do_not_publish_ready(
 }
 
 #[fixture]
-async fn setup_test(
+pub async fn setup_test(
     #[future] create_validator_store: Arc<ValidatorStore>,
     #[future] create_public_api: (PublicApiContext, impl Stream<Item = RuntimeEvent>),
 ) -> (

--- a/crates/topos-tce/src/tests/network.rs
+++ b/crates/topos-tce/src/tests/network.rs
@@ -1,0 +1,101 @@
+use std::sync::Arc;
+
+use libp2p::PeerId;
+use prost::Message;
+use rstest::rstest;
+use test_log::test;
+use tokio::sync::mpsc;
+use topos_core::api::grpc::tce::v1::{double_echo_request, DoubleEchoRequest, Echo, Gossip, Ready};
+use topos_crypto::{messages::MessageSigner, validator_id::ValidatorId};
+use topos_test_sdk::{
+    certificates::create_certificate_chain,
+    constants::{SOURCE_SUBNET_ID_1, TARGET_SUBNET_ID_1},
+};
+
+use crate::AppContext;
+
+use super::setup_test;
+
+#[rstest]
+#[test(tokio::test)]
+async fn handle_gossip(
+    #[future] setup_test: (
+        AppContext,
+        mpsc::Receiver<topos_p2p::Command>,
+        Arc<MessageSigner>,
+    ),
+) {
+    let (mut context, mut p2p_receiver, message_signer) = setup_test.await;
+    let mut certificates = create_certificate_chain(SOURCE_SUBNET_ID_1, &[TARGET_SUBNET_ID_1], 1);
+    let certificate = certificates.pop().unwrap().certificate;
+
+    let msg = DoubleEchoRequest {
+        request: Some(double_echo_request::Request::Gossip(Gossip {
+            certificate: Some(certificate.into()),
+        })),
+    };
+    context
+        .on_net_event(topos_p2p::Event::Gossip {
+            from: PeerId::random(),
+            data: msg.encode_to_vec(),
+        })
+        .await;
+}
+
+#[rstest]
+#[test(tokio::test)]
+async fn handle_echo(
+    #[future] setup_test: (
+        AppContext,
+        mpsc::Receiver<topos_p2p::Command>,
+        Arc<MessageSigner>,
+    ),
+) {
+    let (mut context, mut p2p_receiver, message_signer) = setup_test.await;
+    let mut certificates = create_certificate_chain(SOURCE_SUBNET_ID_1, &[TARGET_SUBNET_ID_1], 1);
+    let certificate = certificates.pop().unwrap().certificate;
+    let validator_id: ValidatorId = message_signer.public_address.into();
+
+    let msg = DoubleEchoRequest {
+        request: Some(double_echo_request::Request::Echo(Echo {
+            certificate_id: Some(certificate.id.into()),
+            signature: Some(message_signer.sign_message(&[]).ok().unwrap().into()),
+            validator_id: Some(validator_id.into()),
+        })),
+    };
+    context
+        .on_net_event(topos_p2p::Event::Gossip {
+            from: PeerId::random(),
+            data: msg.encode_to_vec(),
+        })
+        .await;
+}
+
+#[rstest]
+#[test(tokio::test)]
+async fn handle_ready(
+    #[future] setup_test: (
+        AppContext,
+        mpsc::Receiver<topos_p2p::Command>,
+        Arc<MessageSigner>,
+    ),
+) {
+    let (mut context, mut p2p_receiver, message_signer) = setup_test.await;
+    let mut certificates = create_certificate_chain(SOURCE_SUBNET_ID_1, &[TARGET_SUBNET_ID_1], 1);
+    let certificate = certificates.pop().unwrap().certificate;
+    let validator_id: ValidatorId = message_signer.public_address.into();
+
+    let msg = DoubleEchoRequest {
+        request: Some(double_echo_request::Request::Ready(Ready {
+            certificate_id: Some(certificate.id.into()),
+            signature: Some(message_signer.sign_message(&[]).ok().unwrap().into()),
+            validator_id: Some(validator_id.into()),
+        })),
+    };
+    context
+        .on_net_event(topos_p2p::Event::Gossip {
+            from: PeerId::random(),
+            data: msg.encode_to_vec(),
+        })
+        .await;
+}


### PR DESCRIPTION
# Description

Adds some logs to debug and understand how the node behave and what it does when receiving certificate on an inconsistent network.

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
