### PR TITLE
chore: adding context to p2p msg received

### DIFF
--- a/crates/topos-tce/src/app_context/network.rs
+++ b/crates/topos-tce/src/app_context/network.rs
@@ -82,9 +82,16 @@ impl AppContext {
                             );
                             e
                         });
+
                         if let (Ok(certificate_id), Ok(validator_id)) =
                             (certificate_id, validator_id)
                         {
+                            debug!(
+                                "Received Echo message, certificate_id: {certificate_id}, \
+                                 validator_id: {validator_id} from {from}",
+                                certificate_id = certificate_id,
+                                validator_id = validator_id
+                            );
                             if let Err(e) = channel
                                 .send(DoubleEchoCommand::Echo {
                                     signature: signature.into(),
@@ -124,6 +131,12 @@ impl AppContext {
                         if let (Ok(certificate_id), Ok(validator_id)) =
                             (certificate_id, validator_id)
                         {
+                            debug!(
+                                "Received Ready message, certificate_id: {certificate_id}, \
+                                 validator_id: {validator_id} from {from}",
+                                certificate_id = certificate_id,
+                                validator_id = validator_id
+                            );
                             if let Err(e) = channel
                                 .send(DoubleEchoCommand::Ready {
                                     signature: signature.into(),


### PR DESCRIPTION
# Description

Adds some logs to debug the different messages received by a node on the different `topics`.
For each `Echo/Ready` we will have a debug information telling which validator is the source of the message, which node forwarded to us.

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
