### PR TITLE
feat: update double echo to use pending CF

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7746,6 +7746,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-stream",
+ "tokio-util",
  "topos-core",
  "topos-crypto",
  "topos-metrics",

--- a/crates/topos-p2p/src/config.rs
+++ b/crates/topos-p2p/src/config.rs
@@ -7,6 +7,7 @@ pub struct NetworkConfig {
     pub discovery: DiscoveryConfig,
     pub yamux_max_buffer_size: usize,
     pub yamux_window_size: Option<u32>,
+    pub is_bootnode: bool,
 }
 
 impl Default for NetworkConfig {
@@ -18,6 +19,7 @@ impl Default for NetworkConfig {
             discovery: Default::default(),
             yamux_max_buffer_size: usize::MAX,
             yamux_window_size: None,
+            is_bootnode: false,
         }
     }
 }

--- a/crates/topos-p2p/src/network.rs
+++ b/crates/topos-p2p/src/network.rs
@@ -79,14 +79,14 @@ impl<'a> NetworkBuilder<'a> {
         self
     }
 
-    pub fn public_addresses(mut self, addresses: Vec<Multiaddr>) -> Self {
-        self.public_addresses = Some(addresses);
+    pub fn public_addresses<M: Into<Vec<Multiaddr>>>(mut self, addresses: M) -> Self {
+        self.public_addresses = Some(addresses.into());
 
         self
     }
 
-    pub fn listen_addresses(mut self, addresses: Vec<Multiaddr>) -> Self {
-        self.listen_addresses = Some(addresses);
+    pub fn listen_addresses<M: Into<Vec<Multiaddr>>>(mut self, addresses: M) -> Self {
+        self.listen_addresses = Some(addresses.into());
 
         self
     }

--- a/crates/topos-p2p/src/network.rs
+++ b/crates/topos-p2p/src/network.rs
@@ -200,7 +200,6 @@ impl<'a> NetworkBuilder<'a> {
                 swarm,
                 config: self.config,
                 peer_set: self.known_peers.iter().map(|(p, _)| *p).collect(),
-                is_boot_node: self.known_peers.is_empty(),
                 command_receiver,
                 event_sender,
                 local_peer_id: peer_id,
@@ -212,5 +211,11 @@ impl<'a> NetworkBuilder<'a> {
                 shutdown,
             },
         ))
+    }
+
+    pub fn is_bootnode(mut self, is_bootnode: bool) -> Self {
+        self.config.is_bootnode = is_bootnode;
+
+        self
     }
 }

--- a/crates/topos-p2p/src/runtime/mod.rs
+++ b/crates/topos-p2p/src/runtime/mod.rs
@@ -81,14 +81,8 @@ impl Runtime {
 
             // We were able to send the DHT query, starting the bootstrap
             // We may want to remove the bootstrap at some point
-            if self
-                .swarm
-                .behaviour_mut()
-                .discovery
-                .inner
-                .bootstrap()
-                .is_err()
-            {
+            if let Err(error) = self.swarm.behaviour_mut().discovery.inner.bootstrap() {
+                error!("Unable to start kademlia bootstrap: {error:?}");
                 return Err(Box::new(P2PError::BootstrapError(
                     "Unable to start kademlia bootstrap",
                 )));

--- a/crates/topos-p2p/src/runtime/mod.rs
+++ b/crates/topos-p2p/src/runtime/mod.rs
@@ -29,7 +29,6 @@ pub struct Runtime {
     pub(crate) listening_on: Vec<Multiaddr>,
     pub(crate) public_addresses: Vec<Multiaddr>,
     pub(crate) bootstrapped: bool,
-    pub(crate) is_boot_node: bool,
 
     /// Contains current listenerId of the swarm
     pub active_listeners: HashSet<ListenerId>,
@@ -74,8 +73,8 @@ impl Runtime {
             }
         }
 
-        debug!("Starting a boot node ? {:?}", self.is_boot_node);
-        if !self.is_boot_node {
+        debug!("Starting a boot node ? {:?}", self.config.is_bootnode);
+        if !self.config.is_bootnode {
             // First we need to be known and known some peers before publishing our addresses to
             // the network.
             let mut publish_retry = self.config.publish_retry;

--- a/crates/topos-p2p/src/tests/command/random_peer.rs
+++ b/crates/topos-p2p/src/tests/command/random_peer.rs
@@ -15,8 +15,8 @@ async fn no_random_peer() {
 
     let (client, _, runtime) = crate::network::builder()
         .peer_key(local.keypair.clone())
-        .exposed_addresses(local.addr.clone())
-        .listen_addr(local.addr.clone())
+        .public_addresses(&[local.addr.clone()])
+        .listen_addresses(&[local.addr.clone()])
         .public_addresses(vec![local.addr.clone()])
         .listen_addresses(vec![local.addr.clone()])
         .is_bootnode(true)

--- a/crates/topos-p2p/src/tests/command/random_peer.rs
+++ b/crates/topos-p2p/src/tests/command/random_peer.rs
@@ -15,8 +15,11 @@ async fn no_random_peer() {
 
     let (client, _, runtime) = crate::network::builder()
         .peer_key(local.keypair.clone())
+        .exposed_addresses(local.addr.clone())
+        .listen_addr(local.addr.clone())
         .public_addresses(vec![local.addr.clone()])
         .listen_addresses(vec![local.addr.clone()])
+        .is_bootnode(true)
         .build()
         .await
         .expect("Unable to create p2p network");
@@ -48,6 +51,7 @@ async fn return_a_peer() {
         .peer_key(local.keypair.clone())
         .public_addresses(vec![local.addr.clone()])
         .listen_addresses(vec![local.addr.clone()])
+        .is_bootnode(true)
         .build()
         .await
         .expect("Unable to create p2p network");
@@ -77,6 +81,7 @@ async fn return_a_random_peer_among_100() {
         .peer_key(local.keypair.clone())
         .public_addresses(vec![local.addr.clone()])
         .listen_addresses(vec![local.addr.clone()])
+        .is_bootnode(true)
         .build()
         .await
         .expect("Unable to create p2p network");

--- a/crates/topos-tce-broadcast/Cargo.toml
+++ b/crates/topos-tce-broadcast/Cargo.toml
@@ -16,6 +16,7 @@ serde.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["full"] }
 tokio-stream = { workspace = true, features = ["sync"] }
+tokio-util.workspace = true
 tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }
 tracing.workspace = true
 tce_transport = { package = "topos-tce-transport", path = "../topos-tce-transport"}

--- a/crates/topos-tce-broadcast/src/constant.rs
+++ b/crates/topos-tce-broadcast/src/constant.rs
@@ -19,18 +19,6 @@ lazy_static! {
             .ok()
             .and_then(|s| s.parse().ok())
             .unwrap_or(2048);
-    /// Size of the channel to send updated subscriptions views to the double echo
-    pub static ref SUBSCRIPTION_VIEW_CHANNEL_SIZE: usize =
-        std::env::var("TOPOS_SUBSCRIPTION_VIEW_CHANNEL_SIZE")
-            .ok()
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(2048);
-    /// Size of the channel to send updated subscriptions views to the double echo
-    pub static ref BROADCAST_TASK_COMPLETION_CHANNEL_SIZE: usize =
-        std::env::var("BROADCAST_TASK_COMPLETION_CHANNEL_SIZE")
-            .ok()
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(2048);
     /// Capacity alert threshold for the double echo command channel
     pub static ref COMMAND_CHANNEL_CAPACITY: usize = COMMAND_CHANNEL_SIZE
         .checked_mul(10)
@@ -39,10 +27,10 @@ lazy_static! {
             r
         })
         .unwrap_or(*COMMAND_CHANNEL_SIZE);
-    /// Size of the double echo buffer
-    pub static ref TOPOS_DOUBLE_ECHO_MAX_BUFFER_SIZE: usize =
-        std::env::var("TOPOS_BROADCAST_MAX_BUFFER_SIZE")
-            .ok()
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(crate::double_echo::DoubleEcho::MAX_BUFFER_SIZE);
+    ///
+    pub static ref PENDING_LIMIT_PER_REQUEST_TO_STORAGE: usize =
+        std::env::var("TOPOS_PENDING_LIMIT_PER_REQUEST_TO_STORAGE")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(1000);
 }

--- a/crates/topos-tce-broadcast/src/double_echo/mod.rs
+++ b/crates/topos-tce-broadcast/src/double_echo/mod.rs
@@ -19,6 +19,7 @@ use std::collections::HashSet;
 use std::sync::Arc;
 use tce_transport::{ProtocolEvents, ReliableBroadcastParams};
 use tokio::sync::{broadcast, mpsc, oneshot};
+use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use topos_core::{
     types::ValidatorId,
@@ -96,7 +97,7 @@ impl DoubleEcho {
     pub fn spawn_task_manager(
         &mut self,
         task_manager_message_receiver: mpsc::Receiver<DoubleEchoCommand>,
-    ) -> mpsc::Receiver<(CertificateId, TaskStatus)> {
+    ) -> (JoinHandle<()>, mpsc::Receiver<(CertificateId, TaskStatus)>) {
         let (task_completion_sender, task_completion_receiver) = mpsc::channel(2048);
 
         let task_manager = crate::task_manager::TaskManager::new(
@@ -111,9 +112,9 @@ impl DoubleEcho {
             self.broadcast_sender.clone(),
         );
 
-        tokio::spawn(task_manager.run(self.task_manager_cancellation.child_token()));
+        let handler = tokio::spawn(task_manager.run(self.task_manager_cancellation.child_token()));
 
-        task_completion_receiver
+        (handler, task_completion_receiver)
     }
 
     /// DoubleEcho main loop
@@ -127,7 +128,9 @@ impl DoubleEcho {
         mut self,
         task_manager_message_receiver: mpsc::Receiver<DoubleEchoCommand>,
     ) {
-        let mut task_completion = self.spawn_task_manager(task_manager_message_receiver);
+        let mut shutdown_notifier: Option<oneshot::Sender<()>> = None;
+        let (mut task_manager_termination, mut task_completion) =
+            self.spawn_task_manager(task_manager_message_receiver);
 
         info!("DoubleEcho started");
 
@@ -135,17 +138,19 @@ impl DoubleEcho {
             tokio::select! {
                 biased;
 
+                _ = &mut task_manager_termination => {
+                    break shutdown_notifier;
+                }
+
                 shutdown = self.shutdown.recv() => {
                         warn!("Double echo shutdown signal received {:?}", shutdown);
                         self.task_manager_cancellation.cancel();
-                        break shutdown;
+                        shutdown_notifier = shutdown;
                 },
                 Some(command) = self.command_receiver.recv() => {
                     match command {
 
-                        DoubleEchoCommand::Broadcast { need_gossip, cert } => {
-                            _ = self.broadcast(cert, need_gossip).await;
-                        },
+                        DoubleEchoCommand::Broadcast { need_gossip, cert } if !self.task_manager_cancellation.is_cancelled() => self.broadcast(cert, need_gossip).await,
 
                         command if self.subscriptions.is_some() => {
                             match command {

--- a/crates/topos-tce-broadcast/src/task_manager/mod.rs
+++ b/crates/topos-tce-broadcast/src/task_manager/mod.rs
@@ -103,7 +103,7 @@ impl TaskManager {
                             for (pending_id, certificate) in pendings {
                                 debug!("Creating task for pending certificate {} if needed", certificate.id);
                                 self.create_task(&certificate, true);
-                                self.latest_pending_id = pending_id + 1;
+                                self.latest_pending_id = pending_id;
                             }
                         }
                         Err(error) => {

--- a/crates/topos-tce-broadcast/src/task_manager/mod.rs
+++ b/crates/topos-tce-broadcast/src/task_manager/mod.rs
@@ -101,7 +101,7 @@ impl TaskManager {
                         Ok(pendings) => {
                             debug!("Received {} pending certificates", pendings.len());
                             for (pending_id, certificate) in pendings {
-                                debug!("Creating task for pending certificate {} if needed", certificate.id);
+                                debug!("Creating task for pending certificate {} at position {} if needed", certificate.id, pending_id);
                                 self.create_task(&certificate, true);
                                 self.latest_pending_id = pending_id + 1;
                             }

--- a/crates/topos-tce-broadcast/src/task_manager/mod.rs
+++ b/crates/topos-tce-broadcast/src/task_manager/mod.rs
@@ -95,7 +95,7 @@ impl TaskManager {
             tokio::select! {
                 biased;
 
-                _ = interval.tick(), if !shutdown_receiver.is_cancelled() => {
+                _ = interval.tick() => {
                     debug!("Checking for next pending_certificates");
                     match self.validator_store.get_next_pending_certificates(&self.latest_pending_id, 1000) {
                         Ok(pendings) => {
@@ -103,7 +103,7 @@ impl TaskManager {
                             for (pending_id, certificate) in pendings {
                                 debug!("Creating task for pending certificate {} at position {} if needed", certificate.id, pending_id);
                                 self.create_task(&certificate, true);
-                                self.latest_pending_id = pending_id + 1;
+                                self.latest_pending_id = pending_id;
                             }
                         }
                         Err(error) => {
@@ -123,13 +123,10 @@ impl TaskManager {
                                     .push(msg);
                             };
                         }
-                        DoubleEchoCommand::Broadcast { ref cert, need_gossip } if !shutdown_receiver.is_cancelled() => {
+                        DoubleEchoCommand::Broadcast { ref cert, need_gossip } => {
                             debug!("Received broadcast message for certificate {} ", cert.id);
 
                             self.create_task(cert, need_gossip)
-                        }
-                        DoubleEchoCommand::Broadcast{..} => {
-                            // Ignored due to shutdown
                         }
                     }
                 }
@@ -144,10 +141,6 @@ impl TaskManager {
                     } else {
                         debug!("Task for certificate {} finished unsuccessfully", certificate_id);
                     }
-
-                    if shutdown_receiver.is_cancelled() && self.tasks.is_empty() {
-                        break;
-                    }
                 }
 
                 _ = shutdown_receiver.cancelled() => {
@@ -156,10 +149,13 @@ impl TaskManager {
                     warn!("There is still {} active tasks", self.tasks.len());
                     if !self.tasks.is_empty() {
                         debug!("Certificate still in broadcast: {:?}", self.tasks.keys());
-                        warn!("There is still {} buffered messages", self.buffered_messages.len());
-                    } else {
-                        break;
                     }
+                    warn!("There is still {} buffered messages", self.buffered_messages.len());
+                    for task in self.tasks.iter() {
+                        task.1.shutdown_sender.send(()).await.unwrap();
+                    }
+
+                    break;
                 }
             }
         }

--- a/crates/topos-tce-broadcast/src/tests/task_manager.rs
+++ b/crates/topos-tce-broadcast/src/tests/task_manager.rs
@@ -5,6 +5,7 @@ use tokio::{
     spawn,
     sync::{broadcast, mpsc},
 };
+use tokio_util::sync::CancellationToken;
 use topos_crypto::{messages::MessageSigner, validator_id::ValidatorId};
 use topos_tce_storage::validator::ValidatorStore;
 use topos_test_sdk::{
@@ -23,6 +24,7 @@ async fn can_start(#[future] create_validator_store: Arc<ValidatorStore>) {
     let (task_completion_sender, _) = mpsc::channel(1);
     let (event_sender, _) = mpsc::channel(1);
     let (broadcast_sender, _) = broadcast::channel(1);
+    let shutdown = CancellationToken::new();
     let validator_id = ValidatorId::default();
     let thresholds = tce_transport::ReliableBroadcastParams {
         echo_threshold: 1,
@@ -35,7 +37,7 @@ async fn can_start(#[future] create_validator_store: Arc<ValidatorStore>) {
             .unwrap(),
     );
 
-    let (mut manager, shutdown_receiver) = TaskManager::new(
+    let mut manager = TaskManager::new(
         message_receiver,
         task_completion_sender,
         SubscriptionsView::default(),
@@ -47,7 +49,7 @@ async fn can_start(#[future] create_validator_store: Arc<ValidatorStore>) {
         broadcast_sender,
     );
 
-    spawn(manager.run(shutdown_receiver));
+    spawn(manager.run(shutdown));
 
     let certificates = create_certificate_chain(SOURCE_SUBNET_ID_1, &[TARGET_SUBNET_ID_1], 2);
     let parent = certificates

--- a/crates/topos-tce-storage/src/errors.rs
+++ b/crates/topos-tce-storage/src/errors.rs
@@ -10,6 +10,9 @@ pub enum InternalStorageError {
     #[error("The certificate already exists")]
     CertificateAlreadyExists,
 
+    #[error("The certificate is already in pending")]
+    CertificateAlreadyPending,
+
     #[error("Unable to find a certificate: {0:?}")]
     CertificateNotFound(CertificateId),
 

--- a/crates/topos-tce-storage/src/rocks/db_column.rs
+++ b/crates/topos-tce-storage/src/rocks/db_column.rs
@@ -222,6 +222,13 @@ where
         Ok(ColumnIterator::new(raw_iterator))
     }
 
+    fn iter_at<I: Serialize>(&'a self, index: &I) -> Result<Self::Iterator, InternalStorageError> {
+        let mut raw_iterator = self.rocksdb.raw_iterator_cf(&self.cf()?);
+
+        raw_iterator.seek(be_fix_int_ser(index)?);
+        Ok(ColumnIterator::new(raw_iterator))
+    }
+
     fn iter_with_mode(
         &'a self,
         mode: IteratorMode<'_>,

--- a/crates/topos-tce-storage/src/rocks/db_column.rs
+++ b/crates/topos-tce-storage/src/rocks/db_column.rs
@@ -11,7 +11,7 @@ use rocksdb::{
 };
 
 use bincode::Options;
-use serde::{de::DeserializeOwned, Serialize};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 use crate::errors::InternalStorageError;
 
@@ -278,7 +278,7 @@ where
 }
 
 /// Serialize a value using a fix length serialize and a big endian endianness
-fn be_fix_int_ser<S>(t: &S) -> Result<Vec<u8>, InternalStorageError>
+pub(crate) fn be_fix_int_ser<S>(t: &S) -> Result<Vec<u8>, InternalStorageError>
 where
     S: Serialize + ?Sized,
 {

--- a/crates/topos-tce-storage/src/rocks/map.rs
+++ b/crates/topos-tce-storage/src/rocks/map.rs
@@ -13,6 +13,9 @@ where
     /// Returns an Iterator over the whole CF
     fn iter(&'a self) -> Result<Self::Iterator, InternalStorageError>;
 
+    /// Returns an Iterator over the CF starting from index
+    fn iter_at<I: Serialize>(&'a self, index: &I) -> Result<Self::Iterator, InternalStorageError>;
+
     /// Returns an Iterator over the whole CF with mode configured
     fn iter_with_mode(
         &'a self,

--- a/crates/topos-tce-storage/src/tests/mod.rs
+++ b/crates/topos-tce-storage/src/tests/mod.rs
@@ -500,7 +500,7 @@ async fn get_pending_certificates(store: Arc<ValidatorStore>) {
     let mut expected_pending_certificates = certificates_for_source_subnet_1[10..]
         .iter()
         .enumerate()
-        .map(|(index, certificate)| (index as u64, certificate.certificate.clone()))
+        .map(|(index, certificate)| ((index as u64 + 1), certificate.certificate.clone()))
         .collect::<Vec<_>>();
 
     expected_pending_certificates.extend(
@@ -509,7 +509,7 @@ async fn get_pending_certificates(store: Arc<ValidatorStore>) {
             .enumerate()
             .map(|(index, certificate)| {
                 (
-                    index as u64 + expected_pending_certificates.len() as u64,
+                    (index as u64 + 1) + expected_pending_certificates.len() as u64,
                     certificate.certificate.clone(),
                 )
             })

--- a/crates/topos-tce-storage/src/types.rs
+++ b/crates/topos-tce-storage/src/types.rs
@@ -35,6 +35,7 @@ pub(crate) type TargetSourceListColumn = DBColumn<TargetSourceListKey, Position>
 #[derive(Debug, Clone)]
 pub enum PendingResult {
     AlreadyDelivered,
+    AlreadyPending,
     AwaitPrecedence,
     InPending(PendingCertificateId),
 }

--- a/crates/topos-tce-storage/src/validator/mod.rs
+++ b/crates/topos-tce-storage/src/validator/mod.rs
@@ -253,7 +253,8 @@ impl ValidatorStore {
                 .precedence_pool
                 .insert(&certificate.prev_id, certificate)?;
             debug!(
-                "Certificate {} is now in the precedence pool, {} isn't delivered yet",
+                "Certificate {} is now in the precedence pool, because the previous certificate \
+                 {} isn't delivered yet",
                 certificate.id, certificate.prev_id
             );
 

--- a/crates/topos-tce-storage/src/validator/mod.rs
+++ b/crates/topos-tce-storage/src/validator/mod.rs
@@ -494,6 +494,9 @@ impl WriteStore for ValidatorStore {
             .get(&certificate.certificate.id)
         {
             self.insert_pending_certificate(&certificate)?;
+            self.pending_tables
+                .precedence_pool
+                .delete(&certificate.prev_id)?;
         }
 
         Ok(position)

--- a/crates/topos-tce/src/app_context.rs
+++ b/crates/topos-tce/src/app_context.rs
@@ -141,6 +141,7 @@ impl AppContext {
 
     pub async fn shutdown(&mut self) -> Result<(), Box<dyn std::error::Error>> {
         info!("Shutting down the TCE client...");
+
         self.api_client.shutdown().await?;
         self.tce_cli.shutdown().await?;
         self.gatekeeper.shutdown().await?;

--- a/crates/topos-tce/src/app_context/api.rs
+++ b/crates/topos-tce/src/app_context/api.rs
@@ -39,6 +39,15 @@ impl AppContext {
                         sender.send(Ok(PendingResult::AwaitPrecedence))
                     }
                     Err(StorageError::InternalStorage(
+                        InternalStorageError::CertificateAlreadyPending,
+                    )) => {
+                        debug!(
+                            "Certificate {} has been already added to the pending pool, skipping",
+                            certificate.id
+                        );
+                        sender.send(Ok(PendingResult::AlreadyPending))
+                    }
+                    Err(StorageError::InternalStorage(
                         InternalStorageError::CertificateAlreadyExists,
                     )) => {
                         debug!(
@@ -56,11 +65,6 @@ impl AppContext {
                         sender.send(Err(error.into()))
                     }
                 };
-
-                _ = self
-                    .tce_cli
-                    .broadcast_new_certificate(*certificate, true)
-                    .await;
             }
 
             ApiEvent::GetSourceHead { subnet_id, sender } => {

--- a/crates/topos-tce/src/app_context/api.rs
+++ b/crates/topos-tce/src/app_context/api.rs
@@ -25,16 +25,17 @@ impl AppContext {
                 {
                     Ok(Some(pending_id)) => {
                         debug!(
-                            "Certificate {} has been inserted into pending pool",
-                            certificate.id
+                            "Certificate {} from subnet {} has been inserted into pending pool",
+                            certificate.id, certificate.source_subnet_id
                         );
 
                         sender.send(Ok(PendingResult::InPending(pending_id)))
                     }
                     Ok(None) => {
                         debug!(
-                            "Certificate {} has been inserted into precedence pool",
-                            certificate.id
+                            "Certificate {} from subnet {} has been inserted into precedence pool \
+                             waiting for {}",
+                            certificate.id, certificate.source_subnet_id, certificate.prev_id
                         );
                         sender.send(Ok(PendingResult::AwaitPrecedence))
                     }

--- a/crates/topos-tce/src/app_context/network.rs
+++ b/crates/topos-tce/src/app_context/network.rs
@@ -59,9 +59,9 @@ impl AppContext {
                                 InternalStorageError::CertificateAlreadyPending,
                             )) => {
                                 debug!(
-                                    "Certificate {} has been already added to the pending pool, \
-                                     skipping",
-                                    cert.id
+                                    "Certificate {} from subnet {} has been inserted into \
+                                     precedence pool waiting for {}",
+                                    cert.id, cert.source_subnet_id, cert.prev_id
                                 );
                             }
                             Err(StorageError::InternalStorage(

--- a/crates/topos-tce/src/app_context/network.rs
+++ b/crates/topos-tce/src/app_context/network.rs
@@ -56,6 +56,15 @@ impl AppContext {
                                 );
                             }
                             Err(StorageError::InternalStorage(
+                                InternalStorageError::CertificateAlreadyPending,
+                            )) => {
+                                debug!(
+                                    "Certificate {} has been already added to the pending pool, \
+                                     skipping",
+                                    cert.id
+                                );
+                            }
+                            Err(StorageError::InternalStorage(
                                 InternalStorageError::CertificateAlreadyExists,
                             )) => {
                                 debug!(
@@ -70,23 +79,6 @@ impl AppContext {
                                 );
                             }
                         }
-
-                        spawn(async move {
-                            info!("Send certificate {} to be broadcast", cert.id);
-                            if channel
-                                .send(DoubleEchoCommand::Broadcast {
-                                    cert,
-                                    need_gossip: false,
-                                })
-                                .await
-                                .is_err()
-                            {
-                                error!(
-                                    "Unable to send broadcast_new_certificate command, Receiver \
-                                     was dropped"
-                                );
-                            }
-                        });
                     }
                     Err(e) => {
                         error!("Error converting received certificate {e}");

--- a/crates/topos-tce/src/config.rs
+++ b/crates/topos-tce/src/config.rs
@@ -31,6 +31,7 @@ pub struct TceConfiguration {
     pub version: &'static str,
     pub listen_addresses: Vec<Multiaddr>,
     pub public_addresses: Vec<Multiaddr>,
+    pub is_bootnode: bool,
 }
 
 #[derive(Debug)]

--- a/crates/topos-tce/src/lib.rs
+++ b/crates/topos-tce/src/lib.rs
@@ -144,6 +144,7 @@ pub async fn run(
         .public_addresses(config.public_addresses.clone())
         .known_peers(&boot_peers)
         .grpc_context(grpc_context)
+        .is_bootnode(config.is_bootnode)
         .build()
         .await?;
 

--- a/crates/topos-test-sdk/src/tce/p2p.rs
+++ b/crates/topos-test-sdk/src/tce/p2p.rs
@@ -54,6 +54,7 @@ pub async fn create_network_worker(
         .listen_addresses(addr)
         .minimum_cluster_size(minimum_cluster_size)
         .grpc_context(grpc_context)
+        .is_bootnode(seed == 1)
         .build()
         .await
 }

--- a/crates/topos/src/components/node/services/process.rs
+++ b/crates/topos/src/components/node/services/process.rs
@@ -98,6 +98,7 @@ pub(crate) fn spawn_tce_process(
     }
 
     let tce_config = TceConfiguration {
+        is_bootnode: config.p2p.is_bootnode.unwrap_or_default(),
         boot_peers: genesis
             .boot_peers(Some(topos_p2p::constants::TCE_BOOTNODE_PORT))
             .into_iter()

--- a/crates/topos/src/config/tce.rs
+++ b/crates/topos/src/config/tce.rs
@@ -61,6 +61,8 @@ pub struct P2PConfig {
     /// List of multiaddresses to advertise to the network
     #[serde(default = "default_public_addresses")]
     pub public_addresses: Vec<Multiaddr>,
+
+    pub is_bootnode: Option<bool>,
 }
 
 impl Default for P2PConfig {
@@ -68,6 +70,7 @@ impl Default for P2PConfig {
         Self {
             listen_addresses: default_listen_addresses(),
             public_addresses: default_public_addresses(),
+            is_bootnode: None,
         }
     }
 }


### PR DESCRIPTION
# Description

This PR is the final one regarding the stabilization of the `soft-fork` playbook for `devnet`.

It contains various fixes and changes that allow the network to be upgraded without the need of purging it, allowing the continuity of the delivery while upgrading. This PR biggest change is that the `broadcast` is actively asking for certificates, instead of receiving them from a channel. It allows us to stack incoming certificates in the Storage and process them at node pace. When shutting down, the broadcast will restart from the next certificate still in pending in the Storage.

## Changes per crates

### `topos`

- Update on the `node up` command, the parsing of the `boot_peers` from genesis is needed in order to define the `is-bootnode` config value as soon as possible.
- The `is-bootnode` is a config value but is not available in the config file. Mostly to prevent anyone of defining `is-bootnode = true` directly, relying solely on the `genesis` file.

### `topos-p2p`

- Uses a `is-bootnode` from configuration in place of the old value
- Add new logs in order to detect corner cases such as `kademelia` error when bootstrapping

### `topos-tce-broadcast`

- Refactor how the `task_manager` is handling shutdown
- The `task_manager` will actively request for new `pending` certificates on interval (currently 1sec), improvements need to be made on this, it'll be part of another PR.
- Add logs to better understand the flow of a certificate or message inside the task manager

### `topos-tce-storage`

- Add a new variant on the `InternalStorageError` to catch when a certificate is `CertificateAlreadyPending` 
	- The `PendingResult` also expose a `AlreadyPending`
- Add a new method on `Map` trait to `iter_at` a specific index, implemented in `DBColumn`
- `ValidatorStore` exposes a new `get_next_pending_certificates` allowing to get the next `N` certificates in pending
- Logs have been added to better understand the flow of the certificate inside the storage
- Inserting a pending certificate that is already present will return the newly define `CertificateAlreadyPending`
- The `ValidatorStore` implementation of `insert_certificate_delivered` will now correctly remove the child certificate from `precedence_pool` after adding it to `pending_pool`
- `ValidatorPendingTables` is properly fetching the current `pending_id` from the storage when starting, if not, falling back as expected on `1`

### `topos-tce`

- Dump values of the storage when shutting down to better understand the final state of the node before it stops
- Improve various logs in different places (`app_context/api` and `app_context/network` mostly)


## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
