### PR TITLE
fix: return error from subprocesses

### DIFF
--- a/crates/topos-sequencer/src/lib.rs
+++ b/crates/topos-sequencer/src/lib.rs
@@ -1,5 +1,6 @@
 use crate::app_context::AppContext;
 use std::io::ErrorKind::InvalidInput;
+use std::process::ExitStatus;
 use tokio::{
     spawn,
     sync::{
@@ -171,7 +172,7 @@ pub async fn launch(
 pub async fn run(
     config: SequencerConfiguration,
     shutdown: (CancellationToken, mpsc::Sender<()>),
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> Result<ExitStatus, Box<dyn std::error::Error>> {
     let shutdown_appcontext = shutdown.clone();
 
     let (ctx_send, mut ctx_recv) = oneshot::channel::<AppContext>();
@@ -200,5 +201,5 @@ pub async fn run(
 
     info!("Exited sequencer");
 
-    Ok(())
+    Ok(ExitStatus::default())
 }

--- a/crates/topos-tce/src/lib.rs
+++ b/crates/topos-tce/src/lib.rs
@@ -1,6 +1,7 @@
 use config::TceConfiguration;
 use futures::StreamExt;
 use opentelemetry::global;
+use std::process::ExitStatus;
 use std::{
     future::IntoFuture,
     panic::UnwindSafe,
@@ -46,7 +47,7 @@ const BROADCAST_CHANNEL_SIZE: usize = 10_000;
 pub async fn run(
     config: &TceConfiguration,
     shutdown: (CancellationToken, mpsc::Sender<()>),
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> Result<ExitStatus, Box<dyn std::error::Error>> {
     topos_metrics::init_metrics();
 
     let key = match config.auth_key.as_ref() {
@@ -234,5 +235,5 @@ pub async fn run(
         .await;
 
     global::shutdown_tracer_provider();
-    Ok(())
+    Ok(ExitStatus::default())
 }

--- a/crates/topos/src/components/node/mod.rs
+++ b/crates/topos/src/components/node/mod.rs
@@ -270,7 +270,6 @@ pub(crate) async fn handle_command(
                     shutdown(basic_controller, shutdown_trigger, shutdown_receiver).await;
                 }
                 Some(result) = processes.next() => {
-                    info!("Terminate: {result:?}");
                     shutdown(basic_controller, shutdown_trigger, shutdown_receiver).await;
                     processes.clear();
                     match result {
@@ -286,7 +285,8 @@ pub(crate) async fn handle_command(
                             error!("Terminating with error: {e}");
                             std::process::exit(1);
                         }
-                        Err(_) => {
+                        Err(e) => {
+                            error!("Terminating with error: {e}");
                             std::process::exit(1);
                         }
                     }

--- a/crates/topos/src/components/node/mod.rs
+++ b/crates/topos/src/components/node/mod.rs
@@ -79,13 +79,30 @@ pub(crate) async fn handle_command(
                 println!("Init the node without polygon-edge process...");
             } else {
                 // Generate the Edge configuration
-                if let Ok(result) = services::process::generate_edge_config(
+                match services::process::generate_edge_config(
                     edge_path.join(BINARY_NAME),
                     node_path.clone(),
                 )
                 .await
                 {
-                    if result.is_err() {
+                    Ok(Ok(status)) => {
+                        if let Some(0) = status.code() {
+                            println!("Edge configuration successfully generated");
+                        } else {
+                            println!(
+                                "Edge configuration generation terminated with error status: {:?}",
+                                status
+                            );
+                            remove_dir_all(node_path).expect("failed to remove config folder");
+                            std::process::exit(1);
+                        }
+                    }
+                    Ok(Err(e)) => {
+                        println!("Failed to generate edge config with error {e}");
+                        remove_dir_all(node_path).expect("failed to remove config folder");
+                        std::process::exit(1);
+                    }
+                    Err(e) => {
                         println!("Failed to generate edge config");
                         remove_dir_all(node_path).expect("failed to remove config folder");
                         std::process::exit(1);
@@ -254,11 +271,25 @@ pub(crate) async fn handle_command(
                 }
                 Some(result) = processes.next() => {
                     info!("Terminate: {result:?}");
-                    if let Err(e) = result {
-                        error!("Termination: {e}");
-                    }
                     shutdown(basic_controller, shutdown_trigger, shutdown_receiver).await;
                     processes.clear();
+                    match result {
+                        Ok(Ok(status)) => {
+                            if let Some(0) = status.code() {
+                                info!("Terminating with success error code");
+                            } else {
+                                info!("Terminating with error status: {:?}", status);
+                                std::process::exit(1);
+                            }
+                        }
+                        Ok(Err(e)) => {
+                            error!("Terminating with error: {e}");
+                            std::process::exit(1);
+                        }
+                        Err(_) => {
+                            std::process::exit(1);
+                        }
+                    }
                 }
             };
 

--- a/crates/topos/src/components/node/services/process.rs
+++ b/crates/topos/src/components/node/services/process.rs
@@ -35,17 +35,14 @@ pub fn generate_edge_config(
     info!("Generating the configuration at {config_path:?}");
     info!("Polygon-edge binary located at: {edge_path:?}");
     spawn(async move {
-        match CommandConfig::new(edge_path)
+        CommandConfig::new(edge_path)
             .init(&config_path)
             .spawn()
             .await
-        {
-            Ok(status) => Ok(status),
-            Err(e) => {
-                println!("Failed to run the edge binary: {e:?}");
-                Err(Errors::EdgeTerminated(e))
-            }
-        }
+            .map_err(|e| {
+                error!("Failed to generate the edge configuration: {e:?}");
+                Errors::EdgeTerminated(e)
+            })
     })
 }
 
@@ -123,13 +120,10 @@ pub fn spawn_edge_process(
     edge_args: HashMap<String, String>,
 ) -> JoinHandle<Result<ExitStatus, Errors>> {
     spawn(async move {
-        match CommandConfig::new(edge_path)
+        CommandConfig::new(edge_path)
             .server(&data_dir, &genesis_path, edge_args)
             .spawn()
             .await
-        {
-            Ok(status) => Ok(status),
-            Err(e) => Err(Errors::EdgeTerminated(e)),
-        }
+            .map_err(|e| Errors::EdgeTerminated(e))
     })
 }

--- a/crates/topos/src/components/node/services/process.rs
+++ b/crates/topos/src/components/node/services/process.rs
@@ -124,6 +124,6 @@ pub fn spawn_edge_process(
             .server(&data_dir, &genesis_path, edge_args)
             .spawn()
             .await
-            .map_err(|e| Errors::EdgeTerminated(e))
+            .map_err(Errors::EdgeTerminated)
     })
 }

--- a/crates/topos/src/edge/mod.rs
+++ b/crates/topos/src/edge/mod.rs
@@ -103,8 +103,8 @@ impl CommandConfig {
         let exit_status = running_out?;
 
         info!(
-            "The Edge process is terminated with exit status {:?}; exit code: {:?}, exit signal {:?}, \
-             success: {:?}, raw code: {}",
+            "The Edge process is terminated with exit status {:?}; exit code: {:?}, exit signal \
+             {:?}, success: {:?}, raw code: {}",
             exit_status,
             exit_status.code(),
             exit_status.signal(),

--- a/crates/topos/src/edge/mod.rs
+++ b/crates/topos/src/edge/mod.rs
@@ -1,5 +1,6 @@
 use serde_json::Value;
 use std::collections::HashMap;
+use std::os::unix::prelude::ExitStatusExt;
 use std::path::{Path, PathBuf};
 use std::process::{ExitStatus, Stdio};
 use tokio::{
@@ -99,8 +100,18 @@ impl CommandConfig {
 
         let (running_out, _) = tokio::join!(running, logging);
 
-        info!("The Edge process is terminated with exit status: {running_out:?}");
-        running_out
+        let exit_status = running_out?;
+
+        info!(
+            "The Edge process is terminated with exit status {:?}; exit code: {:?}, exit signal {:?}, \
+             success: {:?}, raw code: {}",
+            exit_status,
+            exit_status.code(),
+            exit_status.signal(),
+            exit_status.success(),
+            exit_status.into_raw(),
+        );
+        Ok(exit_status)
     }
 }
 

--- a/crates/topos/src/edge/mod.rs
+++ b/crates/topos/src/edge/mod.rs
@@ -99,7 +99,7 @@ impl CommandConfig {
 
         let (running_out, _) = tokio::join!(running, logging);
 
-        info!("The Edge process is terminated");
+        info!("The Edge process is terminated with exit status: {running_out:?}");
         running_out
     }
 }


### PR DESCRIPTION
# Description

Return topos cli exit status with respect to edge subprocess status

Fixes TP-825

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
