### PR TITLE
fix: RUSTSEC-2023-0078

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7998,9 +7998,9 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
-version = "0.1.39"
+version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee2ef2af84856a50c1d430afce2fdded0a4ec7eda868db86409b4543df0797f9"
+checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
  "log",
  "pin-project-lite",


### PR DESCRIPTION
# Description

Fixes potential stack use-after-free in `Instrumented::into_inn`. Reference: https://github.com/tokio-rs/tracing/pull/2765

Fixes [RUSTSEC-2023-0078](https://rustsec.org/advisories/RUSTSEC-2023-0078.html)

## PR Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
