### PR TITLE
fix: RUSTSEC-2024-0003

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2856,9 +2856,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91fc23aa11be92976ef4729127f1a74adf36d8436f7816b185d18df956790833"
+checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
 dependencies = [
  "bytes",
  "fnv",
@@ -2866,7 +2866,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap 1.9.3",
+ "indexmap 2.0.2",
  "slab",
  "tokio",
  "tokio-util",


### PR DESCRIPTION
# Description

"Resource exhaustion vulnerability in h2 may lead to Denial of Service (DoS)"

Reference: https://github.com/hyperium/h2/pull/737

Fixes [RUSTSEC-2024-0003](https://rustsec.org/advisories/RUSTSEC-2024-0003.html)

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
