### PR TITLE
fix: clippy unused

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6552,9 +6552,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7cee0529a6d40f580e7a5e6c495c8fbfe21b7b52795ed4bb5e62cdf92bc6380"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,6 @@ members = [
 [workspace.lints.rust]
 # Deny
 missing_docs = "allow"
-unused = "allow"
 
 # Warn
 deprecated-in-future = "warn"

--- a/crates/topos-p2p/src/runtime/handle_command.rs
+++ b/crates/topos-p2p/src/runtime/handle_command.rs
@@ -1,11 +1,9 @@
-use std::collections::hash_map::Entry;
-
 use crate::{
     error::{CommandExecutionError, P2PError},
     protocol_name, Command, Runtime,
 };
 use libp2p::{kad::record::Key, PeerId};
-use rand::{seq::SliceRandom, thread_rng, Rng};
+use rand::{thread_rng, Rng};
 use topos_metrics::P2P_MESSAGE_SENT_ON_GOSSIPSUB_TOTAL;
 use tracing::{debug, error, info, warn};
 
@@ -41,7 +39,7 @@ impl Runtime {
             }
             Command::RandomKnownPeer { sender } => {
                 if self.peer_set.is_empty() {
-                    sender.send(Err(P2PError::CommandError(
+                    let _ = sender.send(Err(P2PError::CommandError(
                         CommandExecutionError::NoKnownPeer,
                     )));
 

--- a/crates/topos-p2p/src/tests/command/random_peer.rs
+++ b/crates/topos-p2p/src/tests/command/random_peer.rs
@@ -24,7 +24,7 @@ async fn no_random_peer() {
         .await
         .expect("Unable to create p2p network");
 
-    let mut runtime = runtime.bootstrap().await.unwrap();
+    let runtime = runtime.bootstrap().await.unwrap();
 
     spawn(runtime.run());
 

--- a/crates/topos-sequencer-subnet-runtime/tests/subnet_contract.rs
+++ b/crates/topos-sequencer-subnet-runtime/tests/subnet_contract.rs
@@ -14,7 +14,7 @@ use std::collections::HashSet;
 use std::process::{Child, Command};
 use std::sync::Arc;
 use test_log::test;
-use tokio::sync::{oneshot, Mutex};
+use tokio::sync::Mutex;
 use topos_core::uci::{Certificate, CertificateId, SubnetId, SUBNET_ID_LENGTH};
 use topos_sequencer_subnet_runtime::proxy::{SubnetRuntimeProxyCommand, SubnetRuntimeProxyEvent};
 use tracing::{error, info, warn, Span};

--- a/crates/topos-sequencer-subnet-runtime/tests/subnet_contract.rs
+++ b/crates/topos-sequencer-subnet-runtime/tests/subnet_contract.rs
@@ -28,7 +28,6 @@ use topos_sequencer_subnet_runtime::{SubnetRuntimeProxyConfig, SubnetRuntimeProx
 use topos_test_sdk::constants::*;
 
 // Local test network with default 2 seconds block
-const STANDALONE_SUBNET: &str = "standalone-test";
 const STANDALONE_SUBNET_BLOCK_TIME: u64 = 2;
 // Local test network with 12 seconds block, usefull for multiple transactions in one block tests
 const STANDALONE_SUBNET_WITH_LONG_BLOCKS_BLOCK_TIME: u64 = 12;
@@ -38,7 +37,6 @@ const SUBNET_RPC_PORT: u32 = 8545;
 const TEST_SECRET_ETHEREUM_KEY: &str =
     "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
 const TEST_ETHEREUM_ACCOUNT: &str = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
-const SUBNET_STARTUP_DELAY: u64 = 5; // seconds left for subnet startup
 const TEST_SUBNET_ID: &str = "6464646464646464646464646464646464646464646464646464646464646464";
 const TOKEN_SYMBOL: &str = "TKX";
 

--- a/crates/topos-tce-api/src/runtime/sync_task.rs
+++ b/crates/topos-tce-api/src/runtime/sync_task.rs
@@ -25,6 +25,7 @@ pub(crate) enum SyncTaskStatus {
     ///  The sync task is active and started running
     Running,
     /// The sync task failed and reported an error
+    #[allow(dead_code)]
     Error(Box<SyncTaskError>),
     /// The sync task exited gracefully and is done pushing certificates to the stream
     Done,

--- a/crates/topos-tce-api/tests/grpc/certificate_precedence.rs
+++ b/crates/topos-tce-api/tests/grpc/certificate_precedence.rs
@@ -2,15 +2,13 @@ use base64ct::{Base64, Encoding};
 use rstest::rstest;
 use std::sync::Arc;
 use test_log::test;
-use tokio_stream::Stream;
 use topos_api::grpc::tce::v1::{GetLastPendingCertificatesRequest, LastPendingCertificate};
 use topos_core::uci::Certificate;
-use topos_tce_api::RuntimeEvent;
 use topos_test_sdk::{
     certificates::create_certificate_chain,
     constants::{SOURCE_SUBNET_ID_1, TARGET_SUBNET_ID_1},
     storage::{create_fullnode_store, create_validator_store, storage_client},
-    tce::public_api::{broadcast_stream, create_public_api, PublicApiContext},
+    tce::public_api::{broadcast_stream, create_public_api},
 };
 
 use topos_tce_storage::{types::CertificateDeliveredWithPositions, validator::ValidatorStore};
@@ -22,12 +20,12 @@ async fn fetch_latest_pending_certificates() {
     let validator_store: Arc<ValidatorStore> =
         create_validator_store(vec![], futures::future::ready(fullnode_store.clone())).await;
 
-    let (tx, rx): (
+    let (_, _): (
         _,
         tokio::sync::broadcast::Receiver<CertificateDeliveredWithPositions>,
     ) = tokio::sync::broadcast::channel(10);
 
-    let (mut api_context, _) = create_public_api(
+    let (api_context, _) = create_public_api(
         storage_client(vec![]),
         broadcast_stream(),
         futures::future::ready(validator_store.clone()),
@@ -73,12 +71,12 @@ async fn fetch_latest_pending_certificates_with_conflicts() {
     let validator_store: Arc<ValidatorStore> =
         create_validator_store(vec![], futures::future::ready(fullnode_store.clone())).await;
 
-    let (tx, rx): (
+    let (_, _): (
         _,
         tokio::sync::broadcast::Receiver<CertificateDeliveredWithPositions>,
     ) = tokio::sync::broadcast::channel(10);
 
-    let (mut api_context, _) = create_public_api(
+    let (api_context, _) = create_public_api(
         storage_client(vec![]),
         broadcast_stream(),
         futures::future::ready(validator_store.clone()),

--- a/crates/topos-tce-api/tests/grpc/certificate_precedence.rs
+++ b/crates/topos-tce-api/tests/grpc/certificate_precedence.rs
@@ -11,7 +11,7 @@ use topos_test_sdk::{
     tce::public_api::{broadcast_stream, create_public_api},
 };
 
-use topos_tce_storage::{types::CertificateDeliveredWithPositions, validator::ValidatorStore};
+use topos_tce_storage::validator::ValidatorStore;
 
 #[rstest]
 #[test(tokio::test)]

--- a/crates/topos-tce-api/tests/grpc/certificate_precedence.rs
+++ b/crates/topos-tce-api/tests/grpc/certificate_precedence.rs
@@ -20,11 +20,6 @@ async fn fetch_latest_pending_certificates() {
     let validator_store: Arc<ValidatorStore> =
         create_validator_store(vec![], futures::future::ready(fullnode_store.clone())).await;
 
-    let (_, _): (
-        _,
-        tokio::sync::broadcast::Receiver<CertificateDeliveredWithPositions>,
-    ) = tokio::sync::broadcast::channel(10);
-
     let (api_context, _) = create_public_api(
         storage_client(vec![]),
         broadcast_stream(),
@@ -70,11 +65,6 @@ async fn fetch_latest_pending_certificates_with_conflicts() {
     let fullnode_store = create_fullnode_store(vec![]).await;
     let validator_store: Arc<ValidatorStore> =
         create_validator_store(vec![], futures::future::ready(fullnode_store.clone())).await;
-
-    let (_, _): (
-        _,
-        tokio::sync::broadcast::Receiver<CertificateDeliveredWithPositions>,
-    ) = tokio::sync::broadcast::channel(10);
 
     let (api_context, _) = create_public_api(
         storage_client(vec![]),

--- a/crates/topos-tce-broadcast/src/double_echo/mod.rs
+++ b/crates/topos-tce-broadcast/src/double_echo/mod.rs
@@ -13,7 +13,6 @@
 //! be ignored by others. `fullnode` still consumes Echo and Ready coming from
 //! validators and use those messages to build their state.
 
-use crate::TaskStatus;
 use crate::{DoubleEchoCommand, SubscriptionsView};
 use std::collections::HashSet;
 use std::sync::Arc;

--- a/crates/topos-tce-broadcast/src/task_manager/mod.rs
+++ b/crates/topos-tce-broadcast/src/task_manager/mod.rs
@@ -86,7 +86,7 @@ impl TaskManager {
         }
     }
 
-    pub async fn run(mut self, mut shutdown_receiver: CancellationToken) {
+    pub async fn run(mut self, shutdown_receiver: CancellationToken) {
         let mut interval = tokio::time::interval(Duration::from_secs(1));
 
         loop {

--- a/crates/topos-tce-broadcast/src/tests/task_manager.rs
+++ b/crates/topos-tce-broadcast/src/tests/task_manager.rs
@@ -36,7 +36,7 @@ async fn can_start(#[future] create_validator_store: Arc<ValidatorStore>) {
             .unwrap(),
     );
 
-    let mut manager = TaskManager::new(
+    let manager = TaskManager::new(
         message_receiver,
         SubscriptionsView::default(),
         event_sender,
@@ -60,21 +60,21 @@ async fn can_start(#[future] create_validator_store: Arc<ValidatorStore>) {
         .take()
         .expect("Failed to create certificate");
 
-    message_sender
+    let _ = message_sender
         .send(crate::DoubleEchoCommand::Broadcast {
             need_gossip: false,
             cert: child.certificate.clone(),
         })
         .await;
 
-    message_sender
+    let _ = message_sender
         .send(crate::DoubleEchoCommand::Broadcast {
             need_gossip: false,
             cert: parent.certificate.clone(),
         })
         .await;
 
-    message_sender
+    let _ = message_sender
         .send(crate::DoubleEchoCommand::Broadcast {
             need_gossip: false,
             cert: parent.certificate.clone(),

--- a/crates/topos-tce-gatekeeper/src/lib.rs
+++ b/crates/topos-tce-gatekeeper/src/lib.rs
@@ -2,7 +2,6 @@ use std::{future::IntoFuture, time::Duration};
 
 use builder::GatekeeperBuilder;
 use futures::{future::BoxFuture, FutureExt};
-use rand::seq::SliceRandom;
 use thiserror::Error;
 use tokio::{
     sync::{mpsc, oneshot},
@@ -16,14 +15,11 @@ mod client;
 mod tests;
 
 pub use client::GatekeeperClient;
-use topos_core::uci::SubnetId;
 use tracing::{info, warn};
 
 pub struct Gatekeeper {
     pub(crate) shutdown: mpsc::Receiver<oneshot::Sender<()>>,
     pub(crate) tick_duration: Duration,
-
-    subnet_list: Vec<SubnetId>,
 }
 
 impl Default for Gatekeeper {
@@ -34,7 +30,6 @@ impl Default for Gatekeeper {
         Self {
             shutdown,
             tick_duration,
-            subnet_list: Vec::default(),
         }
     }
 }

--- a/crates/topos-tce-gatekeeper/src/tests.rs
+++ b/crates/topos-tce-gatekeeper/src/tests.rs
@@ -1,6 +1,6 @@
 use std::future::IntoFuture;
 
-use rstest::{fixture, rstest};
+use rstest::fixture;
 use test_log::test;
 use tokio::spawn;
 use topos_p2p::PeerId;

--- a/crates/topos-tce-storage/src/fullnode/locking.rs
+++ b/crates/topos-tce-storage/src/fullnode/locking.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::{hash_map::RandomState, HashMap},
-    hash::{BuildHasher, Hash, Hasher},
+    hash::{BuildHasher, Hash},
     sync::Arc,
 };
 

--- a/crates/topos-tce-storage/src/rocks/db_column.rs
+++ b/crates/topos-tce-storage/src/rocks/db_column.rs
@@ -11,7 +11,7 @@ use rocksdb::{
 };
 
 use bincode::Options;
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde::{de::DeserializeOwned, Serialize};
 
 use crate::errors::InternalStorageError;
 

--- a/crates/topos-tce-storage/src/types.rs
+++ b/crates/topos-tce-storage/src/types.rs
@@ -56,7 +56,7 @@ pub struct CheckpointSummary {
     sequence_number: usize,
     checkpoint_data: Vec<SourceStreamPosition>,
 }
-pub struct VerifiedCheckpointSummary(CheckpointSummary, ValidatorQuorumSignatureInfo);
+pub struct VerifiedCheckpointSummary((), ());
 
 #[allow(unused)]
 pub struct ValidatorQuorumSignatureInfo {

--- a/crates/topos-tce-storage/src/types.rs
+++ b/crates/topos-tce-storage/src/types.rs
@@ -56,7 +56,8 @@ pub struct CheckpointSummary {
     sequence_number: usize,
     checkpoint_data: Vec<SourceStreamPosition>,
 }
-pub struct VerifiedCheckpointSummary((), ());
+#[allow(unused)]
+pub struct VerifiedCheckpointSummary(CheckpointSummary, ValidatorQuorumSignatureInfo);
 
 #[allow(unused)]
 pub struct ValidatorQuorumSignatureInfo {

--- a/crates/topos-tce-synchronizer/src/checkpoints_collector/mod.rs
+++ b/crates/topos-tce-synchronizer/src/checkpoints_collector/mod.rs
@@ -104,9 +104,6 @@ enum SyncError {
     #[allow(unused)]
     UnableToParseSubnetId,
 
-    #[error("Gatekeeper returned no peer")]
-    NoPeerAvailable,
-
     #[error(transparent)]
     GrpcParsingError(#[from] GrpcParsingError),
 

--- a/crates/topos-tce/src/app_context/network.rs
+++ b/crates/topos-tce/src/app_context/network.rs
@@ -7,7 +7,7 @@ use tokio::spawn;
 use topos_metrics::CERTIFICATE_DELIVERY_LATENCY;
 use topos_p2p::Event as NetEvent;
 use topos_tce_broadcast::DoubleEchoCommand;
-use tracing::{debug, error, info, trace};
+use tracing::{debug, error, trace};
 
 use topos_core::api::grpc::tce::v1::{double_echo_request, DoubleEchoRequest, Echo, Gossip, Ready};
 use topos_core::uci;
@@ -32,7 +32,6 @@ impl AppContext {
                     certificate: Some(certificate),
                 }) => match uci::Certificate::try_from(certificate) {
                     Ok(cert) => {
-                        let channel = self.tce_cli.get_double_echo_channel();
                         if let hash_map::Entry::Vacant(entry) = self.delivery_latency.entry(cert.id)
                         {
                             entry.insert(CERTIFICATE_DELIVERY_LATENCY.start_timer());
@@ -43,7 +42,7 @@ impl AppContext {
                         );
 
                         match self.validator_store.insert_pending_certificate(&cert) {
-                            Ok(Some(pending_id)) => {
+                            Ok(Some(_)) => {
                                 debug!(
                                     "Certificate {} has been inserted into pending pool",
                                     cert.id

--- a/crates/topos-tce/src/app_context/protocol.rs
+++ b/crates/topos-tce/src/app_context/protocol.rs
@@ -1,6 +1,6 @@
 use tce_transport::ProtocolEvents;
 use topos_core::api::grpc::tce::v1::{double_echo_request, DoubleEchoRequest, Echo, Gossip, Ready};
-use tracing::{debug, error, info, warn};
+use tracing::{error, info, warn};
 
 use crate::events::Events;
 use crate::AppContext;

--- a/crates/topos-tce/src/lib.rs
+++ b/crates/topos-tce/src/lib.rs
@@ -2,11 +2,7 @@ use config::TceConfiguration;
 use futures::StreamExt;
 use opentelemetry::global;
 use std::process::ExitStatus;
-use std::{
-    future::IntoFuture,
-    panic::UnwindSafe,
-    sync::{atomic::AtomicBool, Arc},
-};
+use std::{future::IntoFuture, sync::Arc};
 use tokio::{
     spawn,
     sync::{broadcast, mpsc},
@@ -17,7 +13,7 @@ use topos_core::api::grpc::tce::v1::synchronizer_service_server::SynchronizerSer
 use topos_crypto::{messages::MessageSigner, validator_id::ValidatorId};
 use topos_p2p::{
     utils::{local_key_pair, local_key_pair_from_slice},
-    GrpcContext, GrpcRouter, Multiaddr,
+    GrpcContext, GrpcRouter,
 };
 use topos_tce_broadcast::{ReliableBroadcastClient, ReliableBroadcastConfig};
 use topos_tce_storage::{

--- a/crates/topos-tce/src/tests/api.rs
+++ b/crates/topos-tce/src/tests/api.rs
@@ -1,12 +1,9 @@
 use std::sync::Arc;
 
-use libp2p::PeerId;
-use prost::Message;
 use rstest::rstest;
 use test_log::test;
 use tokio::sync::{mpsc, oneshot};
-use topos_core::api::grpc::tce::v1::{double_echo_request, DoubleEchoRequest, Echo, Gossip, Ready};
-use topos_crypto::{messages::MessageSigner, validator_id::ValidatorId};
+use topos_crypto::messages::MessageSigner;
 use topos_tce_storage::{store::WriteStore, types::PendingResult};
 use topos_test_sdk::{
     certificates::create_certificate_chain,
@@ -26,7 +23,7 @@ async fn handle_new_certificate(
         Arc<MessageSigner>,
     ),
 ) {
-    let (mut context, mut p2p_receiver, message_signer) = setup_test.await;
+    let (mut context, _, _) = setup_test.await;
     let mut certificates = create_certificate_chain(SOURCE_SUBNET_ID_1, &[TARGET_SUBNET_ID_1], 1);
     let certificate = certificates.pop().unwrap().certificate;
 
@@ -53,7 +50,7 @@ async fn handle_certificate_in_precedence_pool(
         Arc<MessageSigner>,
     ),
 ) {
-    let (mut context, mut p2p_receiver, message_signer) = setup_test.await;
+    let (mut context, _, _) = setup_test.await;
     let mut certificates = create_certificate_chain(SOURCE_SUBNET_ID_1, &[TARGET_SUBNET_ID_1], 2);
     let certificate = certificates.pop().unwrap().certificate;
 
@@ -80,7 +77,7 @@ async fn handle_certificate_already_delivered(
         Arc<MessageSigner>,
     ),
 ) {
-    let (mut context, mut p2p_receiver, message_signer) = setup_test.await;
+    let (mut context, _, _) = setup_test.await;
     let mut certificates = create_certificate_chain(SOURCE_SUBNET_ID_1, &[TARGET_SUBNET_ID_1], 1);
     let certificate_delivered = certificates.pop().unwrap();
 

--- a/crates/topos-tce/src/tests/network.rs
+++ b/crates/topos-tce/src/tests/network.rs
@@ -26,7 +26,7 @@ async fn handle_gossip(
         Arc<MessageSigner>,
     ),
 ) {
-    let (mut context, mut p2p_receiver, message_signer) = setup_test.await;
+    let (mut context, _, _) = setup_test.await;
     let mut certificates = create_certificate_chain(SOURCE_SUBNET_ID_1, &[TARGET_SUBNET_ID_1], 1);
     let certificate = certificates.pop().unwrap().certificate;
 
@@ -52,7 +52,7 @@ async fn handle_echo(
         Arc<MessageSigner>,
     ),
 ) {
-    let (mut context, mut p2p_receiver, message_signer) = setup_test.await;
+    let (mut context, _, message_signer) = setup_test.await;
     let mut certificates = create_certificate_chain(SOURCE_SUBNET_ID_1, &[TARGET_SUBNET_ID_1], 1);
     let certificate = certificates.pop().unwrap().certificate;
     let validator_id: ValidatorId = message_signer.public_address.into();
@@ -81,7 +81,7 @@ async fn handle_ready(
         Arc<MessageSigner>,
     ),
 ) {
-    let (mut context, mut p2p_receiver, message_signer) = setup_test.await;
+    let (mut context, _, message_signer) = setup_test.await;
     let mut certificates = create_certificate_chain(SOURCE_SUBNET_ID_1, &[TARGET_SUBNET_ID_1], 1);
     let certificate = certificates.pop().unwrap().certificate;
     let validator_id: ValidatorId = message_signer.public_address.into();
@@ -110,7 +110,7 @@ async fn handle_already_delivered(
         Arc<MessageSigner>,
     ),
 ) {
-    let (mut context, mut p2p_receiver, message_signer) = setup_test.await;
+    let (mut context, _, _) = setup_test.await;
     let mut certificates = create_certificate_chain(SOURCE_SUBNET_ID_1, &[TARGET_SUBNET_ID_1], 1);
     let certificate_delivered = certificates.pop().unwrap();
     let certificate = certificate_delivered.certificate.clone();

--- a/crates/topos-test-sdk/src/lib.rs
+++ b/crates/topos-test-sdk/src/lib.rs
@@ -6,6 +6,7 @@ pub mod sequencer;
 pub mod storage;
 pub mod tce;
 
+use rand::Rng;
 use std::{
     collections::HashSet,
     net::SocketAddr,
@@ -17,7 +18,6 @@ use std::{
 };
 
 use lazy_static::lazy_static;
-use rand::Rng;
 use rstest::fixture;
 
 lazy_static! {

--- a/crates/topos-test-sdk/src/storage/mod.rs
+++ b/crates/topos-test-sdk/src/storage/mod.rs
@@ -1,12 +1,6 @@
-use rand::Rng;
 use rstest::fixture;
+use std::path::PathBuf;
 use std::sync::Arc;
-use std::thread;
-use std::{
-    path::PathBuf,
-    str::FromStr,
-    time::{SystemTime, UNIX_EPOCH},
-};
 
 use topos_core::types::CertificateDelivered;
 use topos_tce_storage::{

--- a/crates/topos-test-sdk/src/tce/gatekeeper.rs
+++ b/crates/topos-test-sdk/src/tce/gatekeeper.rs
@@ -1,7 +1,6 @@
 use std::error::Error;
 use std::future::IntoFuture;
 
-use libp2p::PeerId;
 use tokio::spawn;
 use tokio::task::JoinHandle;
 

--- a/crates/topos-test-sdk/src/tce/synchronizer.rs
+++ b/crates/topos-test-sdk/src/tce/synchronizer.rs
@@ -11,7 +11,7 @@ use topos_tce_synchronizer::SynchronizerError;
 use topos_tce_synchronizer::SynchronizerEvent;
 
 pub async fn create_synchronizer(
-    gatekeeper_client: GatekeeperClient,
+    _: GatekeeperClient,
     network_client: NetworkClient,
     store: Arc<ValidatorStore>,
 ) -> (

--- a/crates/topos/src/components/node/mod.rs
+++ b/crates/topos/src/components/node/mod.rs
@@ -102,7 +102,7 @@ pub(crate) async fn handle_command(
                         remove_dir_all(node_path).expect("failed to remove config folder");
                         std::process::exit(1);
                     }
-                    Err(e) => {
+                    Err(_) => {
                         println!("Failed to generate edge config");
                         remove_dir_all(node_path).expect("failed to remove config folder");
                         std::process::exit(1);

--- a/crates/topos/src/components/node/services/process.rs
+++ b/crates/topos/src/components/node/services/process.rs
@@ -1,10 +1,10 @@
 use crate::config::sequencer::SequencerConfig;
 use crate::config::tce::TceConfig;
 use crate::edge::CommandConfig;
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::process::ExitStatus;
 use std::time::Duration;
-use std::{collections::HashMap, task::Wake};
 use thiserror::Error;
 use tokio::{spawn, sync::mpsc, task::JoinHandle};
 use tokio_util::sync::CancellationToken;

--- a/crates/topos/src/config/tce.rs
+++ b/crates/topos/src/config/tce.rs
@@ -1,13 +1,11 @@
 use std::path::Path;
 use std::{net::SocketAddr, path::PathBuf};
 
-use figment::providers::Serialized;
 use figment::{
     providers::{Format, Toml},
     Figment,
 };
-use serde::de::DeserializeOwned;
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Serialize};
 
 use crate::config::Config;
 use topos_p2p::{Multiaddr, PeerId};

--- a/crates/topos/tests/cert_delivery.rs
+++ b/crates/topos/tests/cert_delivery.rs
@@ -22,7 +22,6 @@ use topos_core::{
     },
     uci::{Certificate, SubnetId, CERTIFICATE_ID_LENGTH, SUBNET_ID_LENGTH},
 };
-use topos_tce_transport::ReliableBroadcastParams;
 use topos_test_sdk::{certificates::create_certificate_chains, tce::create_network};
 use tracing::{debug, info, warn};
 

--- a/crates/topos/tests/config.rs
+++ b/crates/topos/tests/config.rs
@@ -1,8 +1,4 @@
-use assert_cmd::{assert, prelude::*};
-use libp2p::swarm::dial_opts::DialOpts;
-use libp2p::swarm::{DialError, ListenError, SwarmEvent};
-use libp2p::{build_multiaddr, Multiaddr, PeerId, Swarm};
-use predicates::prelude::*;
+use assert_cmd::prelude::*;
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
 use std::thread;
@@ -12,7 +8,6 @@ use tokio::fs::OpenOptions;
 use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
 use toml::map::Map;
 use toml::Value;
-use topos::install_polygon_edge;
 use topos_test_sdk::create_folder;
 
 use crate::utils::setup_polygon_edge;
@@ -342,7 +337,6 @@ async fn command_node_up_with_old_config(
     // Create config file
     let node_up_home_env = tmp_home_dir.to_str().unwrap();
     let node_edge_path_env = setup_polygon_edge(node_up_home_env).await;
-    let node_up_role_env = "validator";
     let node_up_name_env = "test_node_up_old_config";
     let node_up_subnet_env = "topos";
 
@@ -388,9 +382,9 @@ async fn command_node_up_with_old_config(
         panic!("TCE configuration table malformed");
     }
 
-    file.set_len(0).await;
-    file.seek(std::io::SeekFrom::Start(0)).await;
-    file.write_all(toml::to_string(&current)?.as_bytes()).await;
+    let _ = file.set_len(0).await;
+    let _ = file.seek(std::io::SeekFrom::Start(0)).await;
+    let _ = file.write_all(toml::to_string(&current)?.as_bytes()).await;
 
     drop(file);
 

--- a/crates/topos/tests/node.rs
+++ b/crates/topos/tests/node.rs
@@ -1,10 +1,6 @@
 mod utils;
 
-use std::{
-    path::PathBuf,
-    process::{Command, ExitStatus},
-    thread,
-};
+use std::{path::PathBuf, process::Command};
 
 use assert_cmd::prelude::*;
 use sysinfo::{Pid, PidExt, ProcessExt, Signal, System, SystemExt};
@@ -81,7 +77,7 @@ async fn command_node_up_sigterm() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut cmd = tokio::process::Command::from(cmd).spawn().unwrap();
     let pid = cmd.id().unwrap();
-    let sigterm_wait = tokio::time::sleep(std::time::Duration::from_secs(10)).await;
+    let _ = tokio::time::sleep(std::time::Duration::from_secs(10)).await;
 
     let s = System::new_all();
     if let Some(process) = s.process(Pid::from_u32(pid)) {

--- a/crates/topos/tests/utils.rs
+++ b/crates/topos/tests/utils.rs
@@ -3,10 +3,11 @@ use predicates::prelude::*;
 use regex::Regex;
 use std::path::PathBuf;
 use std::process::Command;
-use tempfile::tempdir;
 use topos::install_polygon_edge;
 
+// Have to allow dead_code because clippy doesn't recognize it is being used in the tests
 #[cfg(test)]
+#[allow(dead_code)]
 pub fn sanitize_config_folder_path(cmd_out: &str) -> String {
     // Sanitize the result here:
     // When run locally, we get /Users/<username>/.config/topos
@@ -17,6 +18,8 @@ pub fn sanitize_config_folder_path(cmd_out: &str) -> String {
         .to_string()
 }
 
+// Have to allow dead_code because clippy doesn't recognize it is being used in the tests
+#[allow(dead_code)]
 pub async fn setup_polygon_edge(path: &str) -> String {
     let installation_path = std::env::current_dir().unwrap().join(path);
     let binary_path = installation_path.join("polygon-edge");
@@ -37,6 +40,8 @@ pub async fn setup_polygon_edge(path: &str) -> String {
     installation_path.to_str().unwrap().to_string()
 }
 
+// Have to allow dead_code because clippy doesn't recognize it is being used in the tests
+#[allow(dead_code)]
 pub async fn generate_polygon_edge_genesis_file(
     polygon_edge_bin: &str,
     home_path: &str,


### PR DESCRIPTION
# Description

Remove `unused = "allow"` from the `Cargo.toml` to highlight unused imports and variables. Cleaning up the warnings.

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
