### PR TITLE
chore: refactor struct in topos-core

### DIFF
--- a/crates/topos-core/src/api/graphql/checkpoint.rs
+++ b/crates/topos-core/src/api/graphql/checkpoint.rs
@@ -1,16 +1,15 @@
 use async_graphql::InputObject;
-use serde::{Deserialize, Serialize};
 
 use super::{certificate::CertificateId, subnet::SubnetId};
 
-#[derive(Debug, Default, Serialize, Deserialize, InputObject)]
+#[derive(InputObject)]
 pub struct SourceStreamPosition {
     pub source_subnet_id: SubnetId,
     pub position: u64,
     pub certificate_id: Option<CertificateId>,
 }
 
-#[derive(Debug, Default, Serialize, Deserialize, InputObject)]
+#[derive(InputObject)]
 pub struct SourceCheckpoint {
     pub source_subnet_ids: Vec<SubnetId>,
     pub positions: Vec<SourceStreamPosition>,

--- a/crates/topos-core/src/api/graphql/subnet.rs
+++ b/crates/topos-core/src/api/graphql/subnet.rs
@@ -1,32 +1,33 @@
-use async_graphql::{InputObject, SimpleObject};
+use async_graphql::NewType;
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 use tracing::{error, warn};
 
 use super::errors::GraphQLServerError;
 
-#[derive(
-    Clone, Debug, Default, Serialize, Deserialize, SimpleObject, InputObject, PartialEq, Eq,
-)]
-#[graphql(input_name = "SubnetIdInput")]
-pub struct SubnetId {
-    pub value: String,
-}
+#[derive(Clone, Debug, Serialize, Deserialize, NewType, PartialEq, Eq)]
+pub struct SubnetId(pub(crate) String);
 
 impl TryFrom<&SubnetId> for crate::uci::SubnetId {
     type Error = GraphQLServerError;
 
     fn try_from(value: &SubnetId) -> Result<Self, Self::Error> {
-        Self::from_str(value.value.as_str()).map_err(|e| {
+        Self::from_str(value.0.as_str()).map_err(|e| {
             error!("Failed to convert SubnetId from GraphQL input {e:?}");
             GraphQLServerError::ParseDataConnector
         })
     }
 }
 
+impl From<&crate::uci::SubnetId> for SubnetId {
+    fn from(uci_id: &crate::uci::SubnetId) -> Self {
+        Self(uci_id.to_string())
+    }
+}
+
 impl PartialEq<crate::uci::SubnetId> for SubnetId {
     fn eq(&self, other: &crate::uci::SubnetId) -> bool {
-        if let Ok(current) = crate::uci::SubnetId::from_str(&self.value) {
+        if let Ok(current) = crate::uci::SubnetId::from_str(&self.0) {
             other.as_array().eq(current.as_array())
         } else {
             warn!("Unexpected parsing error for subnet id during comparaison");

--- a/crates/topos-tce-api/src/graphql/tests.rs
+++ b/crates/topos-tce-api/src/graphql/tests.rs
@@ -113,11 +113,9 @@ async fn open_watch_certificate_delivered() {
                                 prevId
                                 proof
                                 signature
-                                sourceSubnetId { value }
+                                sourceSubnetId
                                 stateRoot
-                                targetSubnets {
-                                  value
-                                }
+                                targetSubnets
                                 txRootHash
                                 receiptsRootHash
                                 verifier

--- a/crates/topos-tce-api/tests/runtime.rs
+++ b/crates/topos-tce-api/tests/runtime.rs
@@ -558,11 +558,11 @@ async fn can_query_graphql_endpoint_for_certificates(
             certificates(
                 fromSourceCheckpoint: {{
                     sourceSubnetIds: [
-                        {{ value: "{SOURCE_SUBNET_ID_1}" }}
+                        "{SOURCE_SUBNET_ID_1}"
                     ],
                     positions: [
                         {{
-                            sourceSubnetId: {{ value: "{SOURCE_SUBNET_ID_1}" }},
+                            sourceSubnetId:"{SOURCE_SUBNET_ID_1}",
                             position: 0,
                         }}
                     ]
@@ -573,11 +573,9 @@ async fn can_query_graphql_endpoint_for_certificates(
                 prevId
                 proof
                 signature
-                sourceSubnetId {{ value }}
+                sourceSubnetId
                 stateRoot
-                targetSubnets {{
-                    value
-                }}
+                targetSubnets
                 txRootHash
                 receiptsRootHash
                 verifier


### PR DESCRIPTION
# Description

Update some structs after the merge of `topos-core`, `topos-uci` and `topos-api`.

## Breaking changes

BREAKING CHANGE: This break the `0.0.10` GraphQL API definition due to the rename of some fields.

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
