### PR TITLE
chore: remove mention of topos-api from coverage YAML

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -45,7 +45,6 @@ jobs:
             -t lcov \
             --branch \
             --ignore-not-existing \
-            --ignore 'crates/topos-api/src/grpc/generated/*' \
             --ignore 'crates/topos-test-sdk/src/grpc/behaviour/*' \
             --ignore '../**' \
             --ignore '/*' \

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -46,6 +46,7 @@ jobs:
             --branch \
             --ignore-not-existing \
             --ignore 'crates/topos-test-sdk/src/grpc/behaviour/*' \
+            --ignore 'crates/topos-core/src/api/grpc/generated/*' \
             --ignore '../**' \
             --ignore '/*' \
             -o coverage.lcov


### PR DESCRIPTION
Cleanup after #436.
