### PR TITLE
chore: bump version for topos to 0.0.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7364,7 +7364,7 @@ dependencies = [
 
 [[package]]
 name = "topos"
-version = "0.1.0"
+version = "0.0.11"
 dependencies = [
  "assert_cmd",
  "async-stream",

--- a/crates/topos/Cargo.toml
+++ b/crates/topos/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topos"
-version = "0.1.0"
+version = "0.0.11"
 edition = "2021"
 
 [lints]


### PR DESCRIPTION
Bump version for the `topos` crate, which should be in line with the Stack version.
