### PR TITLE
fix: fixing wrong use of IntCounterVec

### DIFF
--- a/crates/topos-metrics/src/lib.rs
+++ b/crates/topos-metrics/src/lib.rs
@@ -11,6 +11,9 @@ mod double_echo;
 mod p2p;
 mod storage;
 
+#[cfg(test)]
+mod tests;
+
 pub use api::*;
 pub use double_echo::*;
 pub use p2p::*;

--- a/crates/topos-metrics/src/p2p.rs
+++ b/crates/topos-metrics/src/p2p.rs
@@ -61,7 +61,7 @@ lazy_static! {
         register_int_counter_vec_with_registry!(
             "p2p_message_deserialize_failure_total",
             "Number of message deserialization failure.",
-            &["echo", "ready", "gossip"],
+            &["topic"],
             TOPOS_METRIC_REGISTRY
         )
         .unwrap();
@@ -69,7 +69,7 @@ lazy_static! {
         register_int_counter_vec_with_registry!(
             "p2p_message_serialize_failure_total",
             "Number of message serialization failure.",
-            &["echo", "ready", "gossip"],
+            &["topic"],
             TOPOS_METRIC_REGISTRY
         )
         .unwrap();

--- a/crates/topos-metrics/src/tests.rs
+++ b/crates/topos-metrics/src/tests.rs
@@ -1,0 +1,21 @@
+use crate::p2p;
+
+#[test]
+fn increment_echo_failure_ser() {
+    let m = &p2p::P2P_MESSAGE_SERIALIZE_FAILURE_TOTAL;
+
+    m.with_label_values(&["echo"]).inc();
+
+    assert_eq!(m.get_metric_with_label_values(&["echo"]).unwrap().get(), 1);
+    assert_eq!(m.get_metric_with_label_values(&["ready"]).unwrap().get(), 0);
+}
+
+#[test]
+fn increment_echo_failure_des() {
+    let m = &p2p::P2P_MESSAGE_DESERIALIZE_FAILURE_TOTAL;
+
+    m.with_label_values(&["echo"]).inc();
+
+    assert_eq!(m.get_metric_with_label_values(&["echo"]).unwrap().get(), 1);
+    assert_eq!(m.get_metric_with_label_values(&["ready"]).unwrap().get(), 0);
+}


### PR DESCRIPTION
# Description

This PR fixes a wrong configuration for the `IntCounterVec` metrics on `p2p` layer.


## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
