### PR TITLE
feat: move telemetry-otlp setup into telemetry crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7719,6 +7719,7 @@ dependencies = [
  "topos-tce-gatekeeper",
  "topos-tce-storage",
  "topos-tce-synchronizer",
+ "topos-telemetry",
  "topos-test-sdk",
  "topos-wallet",
  "tower",
@@ -8219,10 +8220,12 @@ name = "topos-telemetry"
 version = "0.1.0"
 dependencies = [
  "opentelemetry",
+ "opentelemetry-otlp",
  "serde",
  "tonic 0.10.2",
  "tracing",
  "tracing-opentelemetry",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/crates/topos-telemetry/Cargo.toml
+++ b/crates/topos-telemetry/Cargo.toml
@@ -12,4 +12,10 @@ tracing-opentelemetry.workspace = true
 tracing.workspace = true
 tonic.workspace = true
 
+tracing-subscriber = { optional = true, workspace = true, features = ["env-filter", "json", "ansi", "fmt"] }
+opentelemetry-otlp = { optional = true, workspace = true, features = ["grpc-tonic", "metrics", "tls-roots"] }
+
 serde = { workspace = true, features = ["derive", "std"] }
+
+[features]
+tracing = ["tracing-subscriber", "opentelemetry-otlp"]

--- a/crates/topos-telemetry/src/lib.rs
+++ b/crates/topos-telemetry/src/lib.rs
@@ -1,5 +1,6 @@
 use std::{collections::HashMap, str::FromStr};
 
+use ::tracing::warn;
 use opentelemetry::{
     global,
     propagation::{Extractor, Injector},
@@ -7,6 +8,9 @@ use opentelemetry::{
 };
 use serde::{Deserialize, Serialize};
 use tonic::metadata::MetadataKey;
+
+#[cfg(feature = "tracing")]
+pub mod tracing;
 
 pub struct TonicMetaInjector<'a>(pub &'a mut tonic::metadata::MetadataMap);
 pub struct TonicMetaExtractor<'a>(pub &'a tonic::metadata::MetadataMap);
@@ -32,10 +36,10 @@ impl<'a> Injector for TonicMetaInjector<'a> {
             if let Ok(val) = value.parse() {
                 self.0.insert(key, val);
             } else {
-                tracing::warn!("Invalid value: {}", value);
+                warn!("Invalid value: {}", value);
             }
         } else {
-            tracing::warn!("Invalid key: {}", key);
+            warn!("Invalid key: {}", key);
         }
     }
 }

--- a/crates/topos-telemetry/src/tracing.rs
+++ b/crates/topos-telemetry/src/tracing.rs
@@ -20,11 +20,11 @@ fn verbose_to_level(verbose: u8) -> Level {
     }
 }
 
-fn build_resources(otlp_service_name: String) -> Vec<KeyValue> {
+fn build_resources(otlp_service_name: String, version: &'static str) -> Vec<KeyValue> {
     let mut resources = Vec::new();
 
     resources.push(KeyValue::new("service.name", otlp_service_name));
-    resources.push(KeyValue::new("service.version", env!("TOPOS_VERSION")));
+    resources.push(KeyValue::new("service.version", version));
 
     let custom_resources: Vec<_> = std::env::var("TOPOS_OTLP_TAGS")
         .unwrap_or_default()
@@ -60,11 +60,12 @@ fn create_filter(verbose: u8) -> EnvFilter {
 
 // Setup tracing
 // If otlp agent and otlp service name are provided, opentelemetry collection will be used
-pub(crate) fn setup_tracing(
+pub fn setup_tracing(
     verbose: u8,
     no_color: bool,
     otlp_agent: Option<String>,
     otlp_service_name: Option<String>,
+    version: &'static str,
 ) -> Result<Option<BasicController>, Box<dyn std::error::Error>> {
     let mut layers = Vec::new();
 
@@ -98,7 +99,7 @@ pub(crate) fn setup_tracing(
     let metrics: Option<_> = if let (Some(otlp_agent), Some(otlp_service_name)) =
         (otlp_agent, otlp_service_name)
     {
-        let resources = build_resources(otlp_service_name);
+        let resources = build_resources(otlp_service_name, version);
 
         let mut trace_config = opentelemetry::sdk::trace::config();
 

--- a/crates/topos/Cargo.toml
+++ b/crates/topos/Cargo.toml
@@ -15,6 +15,7 @@ topos-core = { workspace = true, features = ["api"] }
 topos-certificate-spammer = { path = "../topos-certificate-spammer" }
 topos-tce-broadcast = { path = "../topos-tce-broadcast", optional = true }
 topos-wallet = { path = "../topos-wallet" }
+topos-telemetry = { path = "../topos-telemetry/", features = ["tracing"] }
 
 async-stream.workspace = true
 async-trait.workspace = true

--- a/crates/topos/src/components/node/mod.rs
+++ b/crates/topos/src/components/node/mod.rs
@@ -13,12 +13,12 @@ use tokio::{
 };
 use tokio_util::sync::CancellationToken;
 use tonic::transport::{Channel, Endpoint};
+use topos_telemetry::tracing::setup_tracing;
 use tower::Service;
 use tracing::{error, info};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 
 use self::commands::{NodeCommand, NodeCommands};
-use crate::tracing::setup_tracing;
 use topos_config::{edge::command::BINARY_NAME, genesis::Genesis, Config};
 use topos_config::{node::NodeConfig, node::NodeRole};
 use topos_core::api::grpc::tce::v1::console_service_client::ConsoleServiceClient;
@@ -200,6 +200,7 @@ pub(crate) async fn handle_command(
                 no_color,
                 cmd_cloned.otlp_agent,
                 cmd_cloned.otlp_service_name,
+                env!("TOPOS_VERSION"),
             )?;
 
             let (shutdown_sender, shutdown_receiver) = mpsc::channel(1);

--- a/crates/topos/src/components/regtest/mod.rs
+++ b/crates/topos/src/components/regtest/mod.rs
@@ -6,10 +6,9 @@ use tokio::{
     sync::{mpsc, oneshot},
 };
 use topos_certificate_spammer::CertificateSpammerConfig;
+use topos_telemetry::tracing::setup_tracing;
 use tracing::{error, info};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
-
-use crate::tracing::setup_tracing;
 
 pub(crate) mod commands;
 
@@ -34,8 +33,13 @@ pub(crate) async fn handle_command(
 
             // Setup instrumentation if both otlp agent and otlp service name
             // are provided as arguments
-            let basic_controller =
-                setup_tracing(verbose, false, cmd.otlp_agent, cmd.otlp_service_name)?;
+            let basic_controller = setup_tracing(
+                verbose,
+                false,
+                cmd.otlp_agent,
+                cmd.otlp_service_name,
+                env!("TOPOS_VERSION"),
+            )?;
 
             let (shutdown_sender, shutdown_receiver) = mpsc::channel::<oneshot::Sender<()>>(1);
             let mut runtime = spawn(topos_certificate_spammer::run(config, shutdown_receiver));

--- a/crates/topos/src/main.rs
+++ b/crates/topos/src/main.rs
@@ -2,7 +2,6 @@ use clap::Parser;
 
 pub(crate) mod components;
 pub(crate) mod options;
-mod tracing;
 
 use crate::options::ToposCommand;
 use tracing_log::LogTracer;


### PR DESCRIPTION
# Description

For consistency and further use, move the otlp related configuration setup to `topos-telemetry`.

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
