### PR TITLE
chore: debug 0.0.11 synchronization

### DIFF
--- a/crates/topos-tce-api/src/graphql/query.rs
+++ b/crates/topos-tce-api/src/graphql/query.rs
@@ -112,6 +112,23 @@ impl QueryRoot {
     ) -> Result<Certificate, GraphQLServerError> {
         Self::certificate_by_id(ctx, certificate_id).await
     }
+
+    async fn get_checkpoint(&self, ctx: &Context<'_>) -> Result<Vec<String>, GraphQLServerError> {
+        let store = ctx.data::<Arc<FullNodeStore>>().map_err(|_| {
+            tracing::error!("Failed to get store from context");
+
+            GraphQLServerError::ParseDataConnector
+        })?;
+
+        let checkpoint = store
+            .get_checkpoint()
+            .map_err(|_| GraphQLServerError::StorageError)?;
+
+        Ok(checkpoint
+            .iter()
+            .map(|v| format!("{}:{}", v.0, v.1.position))
+            .collect())
+    }
 }
 
 pub struct SubscriptionRoot;

--- a/crates/topos-tce-broadcast/src/double_echo/broadcast_state.rs
+++ b/crates/topos-tce-broadcast/src/double_echo/broadcast_state.rs
@@ -230,13 +230,20 @@ impl BroadcastState {
 
     fn reached_delivery_threshold(&self) -> bool {
         // If reached the delivery threshold, I can deliver
-        match self
+        let delivery_threshold = match self
             .subscriptions_view
             .network_size
             .checked_sub(self.subscriptions_view.ready.len())
         {
             Some(consumed) => consumed >= self.delivery_threshold,
             None => false,
-        }
+        };
+
+        debug!(
+            "📝 Certificate {} reached Delivery threshold: {}",
+            &self.certificate.id, delivery_threshold
+        );
+
+        delivery_threshold
     }
 }

--- a/crates/topos-tce-storage/src/rocks/map.rs
+++ b/crates/topos-tce-storage/src/rocks/map.rs
@@ -17,6 +17,7 @@ where
     fn iter_at<I: Serialize>(&'a self, index: &I) -> Result<Self::Iterator, InternalStorageError>;
 
     /// Returns an Iterator over the whole CF with mode configured
+    #[allow(dead_code)]
     fn iter_with_mode(
         &'a self,
         mode: IteratorMode<'_>,
@@ -29,6 +30,7 @@ where
     ) -> Result<Self::Iterator, InternalStorageError>;
 
     /// Returns a prefixed Iterator over the CF starting from index
+    #[allow(dead_code)]
     fn prefix_iter_at<P: Serialize, I: Serialize>(
         &'a self,
         prefix: &P,

--- a/crates/topos-tce-storage/src/tests/checkpoints.rs
+++ b/crates/topos-tce-storage/src/tests/checkpoints.rs
@@ -54,7 +54,7 @@ async fn get_checkpoint_diff_with_no_input(store: Arc<ValidatorStore>) {
     }
 
     let checkpoint = store
-        .get_checkpoint_diff(vec![])
+        .get_checkpoint_diff(&[])
         .unwrap()
         .into_iter()
         .map(|(subnet, proofs)| {
@@ -97,7 +97,7 @@ async fn get_checkpoint_diff_with_input(store: Arc<ValidatorStore>) {
     }
 
     let checkpoint = store
-        .get_checkpoint_diff(vec![checkpoint])
+        .get_checkpoint_diff(&[checkpoint])
         .unwrap()
         .into_iter()
         .map(|(subnet, proofs)| {

--- a/crates/topos-tce-storage/src/tests/checkpoints.rs
+++ b/crates/topos-tce-storage/src/tests/checkpoints.rs
@@ -1,0 +1,123 @@
+use std::{collections::HashMap, sync::Arc};
+
+use rstest::rstest;
+use topos_core::uci::SubnetId;
+use topos_test_sdk::{
+    certificates::create_certificate_chain,
+    constants::{SOURCE_SUBNET_ID_1, SOURCE_SUBNET_ID_2, TARGET_SUBNET_ID_1},
+};
+
+use super::support::store;
+use crate::{
+    store::{ReadStore, WriteStore},
+    validator::ValidatorStore,
+};
+
+#[rstest]
+#[tokio::test]
+async fn get_checkpoint_for_two_subnets(store: Arc<ValidatorStore>) {
+    let certificates_a = create_certificate_chain(SOURCE_SUBNET_ID_1, &[TARGET_SUBNET_ID_1], 32);
+    let certificates_b = create_certificate_chain(SOURCE_SUBNET_ID_2, &[TARGET_SUBNET_ID_1], 24);
+
+    for cert in certificates_a {
+        _ = store.insert_certificate_delivered(&cert).await;
+    }
+
+    for cert in certificates_b {
+        _ = store.insert_certificate_delivered(&cert).await;
+    }
+
+    let checkpoint = store
+        .get_checkpoint()
+        .unwrap()
+        .into_iter()
+        .map(|(subnet, value)| (subnet, *value.position))
+        .collect::<HashMap<SubnetId, u64>>();
+
+    assert_eq!(checkpoint.len(), 2);
+    assert_eq!(*checkpoint.get(&SOURCE_SUBNET_ID_1).unwrap(), 31);
+    assert_eq!(*checkpoint.get(&SOURCE_SUBNET_ID_2).unwrap(), 23);
+}
+
+#[rstest]
+#[tokio::test]
+async fn get_checkpoint_diff_with_no_input(store: Arc<ValidatorStore>) {
+    let certificates_a = create_certificate_chain(SOURCE_SUBNET_ID_1, &[TARGET_SUBNET_ID_1], 32);
+    let certificates_b = create_certificate_chain(SOURCE_SUBNET_ID_2, &[TARGET_SUBNET_ID_1], 24);
+
+    for cert in certificates_a {
+        _ = store.insert_certificate_delivered(&cert).await;
+    }
+
+    for cert in certificates_b {
+        _ = store.insert_certificate_delivered(&cert).await;
+    }
+
+    let checkpoint = store
+        .get_checkpoint_diff(vec![])
+        .unwrap()
+        .into_iter()
+        .map(|(subnet, proofs)| {
+            (
+                subnet,
+                proofs
+                    .iter()
+                    .map(|proof| *proof.delivery_position.position)
+                    .collect::<Vec<_>>(),
+            )
+        })
+        .collect::<HashMap<SubnetId, _>>();
+
+    assert_eq!(checkpoint.len(), 2);
+    assert_eq!(
+        *checkpoint.get(&SOURCE_SUBNET_ID_1).unwrap(),
+        (0..=31).collect::<Vec<_>>()
+    );
+    assert_eq!(
+        *checkpoint.get(&SOURCE_SUBNET_ID_2).unwrap(),
+        (0..=23).collect::<Vec<_>>()
+    );
+}
+
+#[rstest]
+#[tokio::test]
+async fn get_checkpoint_diff_with_input(store: Arc<ValidatorStore>) {
+    let certificates_a = create_certificate_chain(SOURCE_SUBNET_ID_1, &[TARGET_SUBNET_ID_1], 32);
+    let certificates_b = create_certificate_chain(SOURCE_SUBNET_ID_2, &[TARGET_SUBNET_ID_1], 24);
+
+    let checkpoint = certificates_a.get(20).unwrap().proof_of_delivery.clone();
+    assert_eq!(*checkpoint.delivery_position.position, 20);
+
+    for cert in certificates_a {
+        _ = store.insert_certificate_delivered(&cert).await;
+    }
+
+    for cert in certificates_b {
+        _ = store.insert_certificate_delivered(&cert).await;
+    }
+
+    let checkpoint = store
+        .get_checkpoint_diff(vec![checkpoint])
+        .unwrap()
+        .into_iter()
+        .map(|(subnet, proofs)| {
+            (
+                subnet,
+                proofs
+                    .iter()
+                    .map(|proof| *proof.delivery_position.position)
+                    .collect::<Vec<_>>(),
+            )
+        })
+        .collect::<HashMap<SubnetId, _>>();
+
+    assert_eq!(checkpoint.len(), 2);
+    assert_eq!(
+        *checkpoint.get(&SOURCE_SUBNET_ID_1).unwrap(),
+        (21..=31).collect::<Vec<_>>()
+    );
+    assert_eq!(
+        *checkpoint.get(&SOURCE_SUBNET_ID_2).unwrap(),
+        (0..=23).collect::<Vec<_>>()
+    );
+}

--- a/crates/topos-tce-storage/src/tests/mod.rs
+++ b/crates/topos-tce-storage/src/tests/mod.rs
@@ -21,6 +21,7 @@ use self::support::store;
 use topos_test_sdk::certificates::create_certificate_chain;
 use topos_test_sdk::constants::*;
 
+mod checkpoints;
 mod db_columns;
 mod pending_certificates;
 mod position;

--- a/crates/topos-tce-storage/src/validator/mod.rs
+++ b/crates/topos-tce-storage/src/validator/mod.rs
@@ -334,6 +334,12 @@ impl ValidatorStore {
             .get(certificate_id)?)
     }
 
+    /// Returns the difference between the `from` list of [ProofOfDelivery] and the local head
+    /// checkpoint. This is used to define the list of certificates that are missing between the
+    /// `from` and the local head checkpoint.
+    /// The maximum number of [ProofOfDelivery] returned per [SubnetId] is 100.
+    /// If the `from` is missing a local subnet, the list of [ProofOfDelivery] for this subnet will
+    /// start from [Position] `0`.
     pub fn get_checkpoint_diff(
         &self,
         from: &[ProofOfDelivery],

--- a/crates/topos-tce-storage/src/validator/mod.rs
+++ b/crates/topos-tce-storage/src/validator/mod.rs
@@ -362,10 +362,12 @@ impl ValidatorStore {
                 if local_position <= position.delivery_position.position {
                     continue;
                 }
+
                 self.fullnode_store
                     .perpetual_tables
                     .streams
-                    .prefix_iter_at(&subnet, &position)?
+                    .prefix_iter(&(&subnet, &position.delivery_position.position))?
+                    .skip(1)
                     .take(100)
                     .map(|(_, v)| v)
                     .collect()
@@ -373,7 +375,7 @@ impl ValidatorStore {
                 self.fullnode_store
                     .perpetual_tables
                     .streams
-                    .prefix_iter(&subnet)?
+                    .prefix_iter(&(&subnet, Position::ZERO))?
                     .take(100)
                     .map(|(_, v)| v)
                     .collect()

--- a/crates/topos-tce-synchronizer/src/checkpoints_collector/mod.rs
+++ b/crates/topos-tce-synchronizer/src/checkpoints_collector/mod.rs
@@ -193,7 +193,10 @@ impl CheckpointSynchronizer {
             let len = proofs.len();
             let unverified_certs = self.store.insert_unverified_proofs(proofs)?;
 
-            debug!("Persist {} unverified proofs for {}", len, subnet);
+            debug!(
+                "Persist {} unverified proof of delivery for {}",
+                len, subnet
+            );
             certs.extend(&unverified_certs[..]);
         }
 

--- a/crates/topos-tce-synchronizer/src/lib.rs
+++ b/crates/topos-tce-synchronizer/src/lib.rs
@@ -166,7 +166,7 @@ impl GrpcSynchronizerService for SynchronizerService {
 
         debug!("Request {} contains {} proof_of_delivery", id, res.len());
         trace!("Request {} contains {:?}", id, res);
-        let diff = match self.validator_store.get_checkpoint_diff(res) {
+        let diff = match self.validator_store.get_checkpoint_diff(&res) {
             Ok(diff) => {
                 debug!(
                     "Fetched checkpoint diff from storage for request {}, got {:?}",

--- a/crates/topos-tce-synchronizer/src/lib.rs
+++ b/crates/topos-tce-synchronizer/src/lib.rs
@@ -28,7 +28,7 @@ use topos_core::{
     uci::CertificateId,
 };
 use topos_tce_storage::{store::ReadStore, validator::ValidatorStore};
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error, info, trace, warn};
 use uuid::Uuid;
 
 pub struct Synchronizer {
@@ -148,7 +148,7 @@ impl GrpcSynchronizerService for SynchronizerService {
             .request_id
             .map(|id| id.into())
             .unwrap_or(Uuid::new_v4());
-        info!("Received request for checkpoint (request_id: {})", id);
+        debug!("Received request for checkpoint (request_id: {})", id);
 
         let res: Result<Vec<_>, _> = request
             .checkpoint
@@ -164,8 +164,8 @@ impl GrpcSynchronizerService for SynchronizerService {
             Ok(value) => value,
         };
 
-        info!("Request {} contains {} proof_of_delivery", id, res.len());
-        debug!("Request {} contains {:?}", id, res);
+        debug!("Request {} contains {} proof_of_delivery", id, res.len());
+        trace!("Request {} contains {:?}", id, res);
         let diff = match self.validator_store.get_checkpoint_diff(res) {
             Ok(diff) => {
                 debug!(
@@ -206,7 +206,7 @@ impl GrpcSynchronizerService for SynchronizerService {
             }
         };
 
-        info!(
+        debug!(
             "Responding to request {} with checkpoint diff containing {:?}",
             id,
             diff.iter()

--- a/crates/topos/src/options/input_format.rs
+++ b/crates/topos/src/options/input_format.rs
@@ -6,9 +6,3 @@ pub(crate) enum InputFormat {
     Json,
     Plain,
 }
-
-pub(crate) trait Parser<T> {
-    type Result;
-
-    fn parse(&self, input: T) -> Self::Result;
-}


### PR DESCRIPTION
# Description

This PR explores the issue with the synchronization of a new node. It solves the issue by refactoring a bit the calculation of diff between local and input.
The problem relied on the `prefix_iter_at` method that was introduced during the synchronization phase, but didn't work as expected in some cases. A ticket has been created to fix or refactor it, in the meantime, the synchronization process is falling back to the `skip` method.

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
