### PR TITLE
feat: add benchmark dns option to spam subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7737,6 +7737,7 @@ dependencies = [
  "clap 4.4.18",
  "futures",
  "hex",
+ "http",
  "lazy_static",
  "opentelemetry",
  "rand",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7737,7 +7737,7 @@ dependencies = [
  "clap 4.4.18",
  "futures",
  "hex",
- "http",
+ "http 0.2.11",
  "lazy_static",
  "opentelemetry",
  "rand",

--- a/crates/topos-certificate-spammer/Cargo.toml
+++ b/crates/topos-certificate-spammer/Cargo.toml
@@ -24,6 +24,7 @@ opentelemetry.workspace = true
 tiny-keccak.workspace = true
 uuid.workspace = true
 lazy_static.workspace = true
+http.workspace = true
 
 toml = "0.5.9"
 

--- a/crates/topos-certificate-spammer/src/config.rs
+++ b/crates/topos-certificate-spammer/src/config.rs
@@ -1,4 +1,4 @@
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct CertificateSpammerConfig {
     pub target_nodes: Option<Vec<String>>,
     pub target_nodes_path: Option<String>,

--- a/crates/topos-certificate-spammer/src/config.rs
+++ b/crates/topos-certificate-spammer/src/config.rs
@@ -9,6 +9,6 @@ pub struct CertificateSpammerConfig {
     pub batch_interval: u64,
     pub target_subnets: Option<Vec<String>>,
     pub benchmark: bool,
-    pub hosts: Option<String>,
+    pub target_hosts: Option<String>,
     pub number: Option<u32>,
 }

--- a/crates/topos-certificate-spammer/src/config.rs
+++ b/crates/topos-certificate-spammer/src/config.rs
@@ -8,7 +8,7 @@ pub struct CertificateSpammerConfig {
     pub nb_batches: Option<u64>,
     pub batch_interval: u64,
     pub target_subnets: Option<Vec<String>>,
-    pub kubernetes: bool,
+    pub benchmark: bool,
     pub dns: Option<String>,
     pub number: Option<u32>,
 }

--- a/crates/topos-certificate-spammer/src/config.rs
+++ b/crates/topos-certificate-spammer/src/config.rs
@@ -8,4 +8,7 @@ pub struct CertificateSpammerConfig {
     pub nb_batches: Option<u64>,
     pub batch_interval: u64,
     pub target_subnets: Option<Vec<String>>,
+    pub kubernetes: bool,
+    pub dns: Option<String>,
+    pub number: Option<u32>,
 }

--- a/crates/topos-certificate-spammer/src/config.rs
+++ b/crates/topos-certificate-spammer/src/config.rs
@@ -9,6 +9,6 @@ pub struct CertificateSpammerConfig {
     pub batch_interval: u64,
     pub target_subnets: Option<Vec<String>>,
     pub benchmark: bool,
-    pub dns: Option<String>,
+    pub hosts: Option<String>,
     pub number: Option<u32>,
 }

--- a/crates/topos-certificate-spammer/src/error.rs
+++ b/crates/topos-certificate-spammer/src/error.rs
@@ -16,6 +16,6 @@ pub enum Error {
     TCENodeConnection(topos_tce_proxy::Error),
     #[error("Certificate signing error: {0}")]
     CertificateSigning(topos_core::uci::Error),
-    #[error("Kubernetes config error: {0}")]
-    KubernetesConfigError(String),
+    #[error("BenchmkarkConfigError config error: {0}")]
+    BenchmarkConfigError(String),
 }

--- a/crates/topos-certificate-spammer/src/error.rs
+++ b/crates/topos-certificate-spammer/src/error.rs
@@ -16,4 +16,6 @@ pub enum Error {
     TCENodeConnection(topos_tce_proxy::Error),
     #[error("Certificate signing error: {0}")]
     CertificateSigning(topos_core::uci::Error),
+    #[error("Kubernetes config error: {0}")]
+    KubernetesConfigError(String),
 }

--- a/crates/topos-certificate-spammer/src/error.rs
+++ b/crates/topos-certificate-spammer/src/error.rs
@@ -17,5 +17,5 @@ pub enum Error {
     #[error("Certificate signing error: {0}")]
     CertificateSigning(topos_core::uci::Error),
     #[error("BenchmkarkConfigError config error: {0}")]
-    BenchmarkConfigError(String),
+    BenchmarkConfig(String),
 }

--- a/crates/topos-certificate-spammer/src/lib.rs
+++ b/crates/topos-certificate-spammer/src/lib.rs
@@ -205,14 +205,14 @@ pub async fn run(
     let target_nodes = if args.benchmark {
         if let (Some(dns), Some(number)) = (args.dns, args.number) {
             if dns.replace("{N}", &0.to_string()).parse::<Uri>().is_err() {
-                return Err(Error::BenchmarkConfigError("Invalid DNS pattern".into()));
+                return Err(Error::BenchmarkConfig("Invalid DNS pattern".into()));
             }
 
             (0..number)
                 .map(|n| dns.replace("{N}", &n.to_string()))
                 .collect::<Vec<String>>()
         } else {
-            return Err(Error::BenchmarkConfigError(
+            return Err(Error::BenchmarkConfig(
                 "DNS pattern or number of nodes not specified".into(),
             ));
         }

--- a/crates/topos-certificate-spammer/src/lib.rs
+++ b/crates/topos-certificate-spammer/src/lib.rs
@@ -201,7 +201,18 @@ pub async fn run(
 
     // Is list of nodes is specified in the command line use them otherwise use
     // config file provided nodes
-    let target_nodes = if let Some(nodes) = args.target_nodes {
+    let target_nodes = if args.kubernetes {
+        // Kubernetes mode
+        if let (Some(dns), Some(number)) = (args.dns, args.number) {
+            (1..=number)
+                .map(|n| dns.replace("{N}", &n.to_string()))
+                .collect::<Vec<String>>()
+        } else {
+            return Err(Error::KubernetesConfigError(
+                "DNS pattern or number of nodes not specified".into(),
+            ));
+        }
+    } else if let Some(nodes) = args.target_nodes {
         nodes
     } else if let Some(target_nodes_path) = args.target_nodes_path {
         let json_str = std::fs::read_to_string(target_nodes_path)

--- a/crates/topos-certificate-spammer/src/lib.rs
+++ b/crates/topos-certificate-spammer/src/lib.rs
@@ -203,17 +203,20 @@ pub async fn run(
     // Is list of nodes is specified in the command line use them otherwise use
     // config file provided nodes
     let target_nodes = if args.benchmark {
-        if let (Some(dns), Some(number)) = (args.dns, args.number) {
-            if dns.replace("{N}", &0.to_string()).parse::<Uri>().is_err() {
-                return Err(Error::BenchmarkConfig("Invalid DNS pattern".into()));
+        if let (Some(hosts), Some(number)) = (args.hosts, args.number) {
+            if hosts.replace("{N}", &0.to_string()).parse::<Uri>().is_err() {
+                return Err(Error::BenchmarkConfig(
+                    "Invalid hosts pattern. Has to be in the format of http://validator-1:9090"
+                        .into(),
+                ));
             }
 
             (0..number)
-                .map(|n| dns.replace("{N}", &n.to_string()))
+                .map(|n| hosts.replace("{N}", &n.to_string()))
                 .collect::<Vec<String>>()
         } else {
             return Err(Error::BenchmarkConfig(
-                "DNS pattern or number of nodes not specified".into(),
+                "hosts pattern or number of nodes not specified".into(),
             ));
         }
     } else if let Some(nodes) = args.target_nodes {

--- a/crates/topos-sequencer-subnet-runtime/tests/subnet_contract.rs
+++ b/crates/topos-sequencer-subnet-runtime/tests/subnet_contract.rs
@@ -337,7 +337,7 @@ async fn deploy_test_token(
             info!("Token deployed: {:?}", r);
         }
         Err(e) => {
-            panic!("Error deploying token: {e}");
+            error!("Unable to deploy token: {e}");
         }
     }
 

--- a/crates/topos-sequencer-subnet-runtime/tests/subnet_contract.rs
+++ b/crates/topos-sequencer-subnet-runtime/tests/subnet_contract.rs
@@ -337,7 +337,7 @@ async fn deploy_test_token(
             info!("Token deployed: {:?}", r);
         }
         Err(e) => {
-            error!("Unable to deploy token: {e}");
+            panic!("Error deploying token: {e}");
         }
     }
 

--- a/crates/topos/src/components/regtest/commands/spam.rs
+++ b/crates/topos/src/components/regtest/commands/spam.rs
@@ -71,14 +71,18 @@ pub struct Spam {
     #[arg(
         long,
         env = "TOPOS_NETWORK_SPAMMER_BENCHMARK",
-        requires = "hosts",
+        requires = "target_hosts",
         requires = "number"
     )]
     pub benchmark: bool,
     /// Template for generating target node entrypoints.
     /// e.g. `--hosts="http://validator-{N}:1340"`
-    #[arg(long, env = "TOPOS_NETWORK_SPAMMER_HOSTS", requires = "benchmark")]
-    pub hosts: Option<String>,
+    #[arg(
+        long,
+        env = "TOPOS_NETWORK_SPAMMER_TARGET_HOSTS",
+        requires = "benchmark"
+    )]
+    pub target_hosts: Option<String>,
     /// Number of nodes to generate based on the DNS template.
     #[arg(long, env = "TOPOS_NETWORK_SPAMMER_NUMBER", requires = "benchmark")]
     pub number: Option<u32>,

--- a/crates/topos/src/components/regtest/commands/spam.rs
+++ b/crates/topos/src/components/regtest/commands/spam.rs
@@ -71,11 +71,11 @@ pub struct Spam {
     #[arg(long, env = "TOPOS_NETWORK_SPAMMER_BENCHMARK")]
     pub benchmark: bool,
     /// DNS template for generating target node addresses.
-    /// e.g. `--dns="http://validator-{N}:1340"`
-    #[arg(long, env = "TOPOS_NETWORK_SPAMMER_DNS")]
-    pub dns: Option<String>,
+    /// e.g. `--hosts="http://validator-{N}:1340"`
+    #[arg(long, env = "TOPOS_NETWORK_SPAMMER_HOSTS", requires = "benchmark")]
+    pub hosts: Option<String>,
     /// Number of nodes to generate based on the DNS template.
-    #[arg(long, env = "TOPOS_NETWORK_SPAMMER_NUMBER")]
+    #[arg(long, env = "TOPOS_NETWORK_SPAMMER_NUMBER", requires = "benchmark")]
     pub number: Option<u32>,
 }
 

--- a/crates/topos/src/components/regtest/commands/spam.rs
+++ b/crates/topos/src/components/regtest/commands/spam.rs
@@ -68,8 +68,8 @@ pub struct Spam {
     #[arg(long, env = "TOPOS_OTLP_SERVICE_NAME")]
     pub otlp_service_name: Option<String>,
     /// Flag to indicate usage of Kubernetes.
-    #[arg(long, env = "TOPOS_NETWORK_SPAMMER_KUBERNETES")]
-    pub kubernetes: bool,
+    #[arg(long, env = "TOPOS_NETWORK_SPAMMER_BENCHMARK")]
+    pub benchmark: bool,
     /// DNS template for generating target node addresses.
     /// e.g. `--dns="http://validator-{N}:1340"`
     #[arg(long, env = "TOPOS_NETWORK_SPAMMER_DNS")]

--- a/crates/topos/src/components/regtest/commands/spam.rs
+++ b/crates/topos/src/components/regtest/commands/spam.rs
@@ -68,7 +68,12 @@ pub struct Spam {
     #[arg(long, env = "TOPOS_OTLP_SERVICE_NAME")]
     pub otlp_service_name: Option<String>,
     /// Flag to indicate usage of Kubernetes.
-    #[arg(long, env = "TOPOS_NETWORK_SPAMMER_BENCHMARK")]
+    #[arg(
+        long,
+        env = "TOPOS_NETWORK_SPAMMER_BENCHMARK",
+        requires = "hosts",
+        requires = "number"
+    )]
     pub benchmark: bool,
     /// DNS template for generating target node addresses.
     /// e.g. `--hosts="http://validator-{N}:1340"`

--- a/crates/topos/src/components/regtest/commands/spam.rs
+++ b/crates/topos/src/components/regtest/commands/spam.rs
@@ -67,6 +67,16 @@ pub struct Spam {
     /// If not provided open telemetry will not be used
     #[arg(long, env = "TOPOS_OTLP_SERVICE_NAME")]
     pub otlp_service_name: Option<String>,
+    /// Flag to indicate usage of Kubernetes.
+    #[arg(long, env = "TOPOS_NETWORK_SPAMMER_KUBERNETES")]
+    pub kubernetes: bool,
+    /// DNS template for generating target node addresses.
+    /// e.g. `--dns="http://validator-{N}:1340"`
+    #[arg(long, env = "TOPOS_NETWORK_SPAMMER_DNS")]
+    pub dns: Option<String>,
+    /// Number of nodes to generate based on the DNS template.
+    #[arg(long, env = "TOPOS_NETWORK_SPAMMER_NUMBER")]
+    pub number: Option<u32>,
 }
 
 impl Spam {}

--- a/crates/topos/src/components/regtest/commands/spam.rs
+++ b/crates/topos/src/components/regtest/commands/spam.rs
@@ -75,7 +75,7 @@ pub struct Spam {
         requires = "number"
     )]
     pub benchmark: bool,
-    /// DNS template for generating target node addresses.
+    /// Template for generating target node entrypoints.
     /// e.g. `--hosts="http://validator-{N}:1340"`
     #[arg(long, env = "TOPOS_NETWORK_SPAMMER_HOSTS", requires = "benchmark")]
     pub hosts: Option<String>,

--- a/crates/topos/src/components/regtest/mod.rs
+++ b/crates/topos/src/components/regtest/mod.rs
@@ -31,7 +31,7 @@ pub(crate) async fn handle_command(
                 batch_interval: cmd.batch_interval,
                 target_subnets: cmd.target_subnets,
                 benchmark: cmd.benchmark,
-                dns: cmd.dns,
+                hosts: cmd.hosts,
                 number: cmd.number,
             };
 

--- a/crates/topos/src/components/regtest/mod.rs
+++ b/crates/topos/src/components/regtest/mod.rs
@@ -30,7 +30,7 @@ pub(crate) async fn handle_command(
                 nb_batches: cmd.nb_batches,
                 batch_interval: cmd.batch_interval,
                 target_subnets: cmd.target_subnets,
-                kubernetes: cmd.kubernetes,
+                benchmark: cmd.benchmark,
                 dns: cmd.dns,
                 number: cmd.number,
             };

--- a/crates/topos/src/components/regtest/mod.rs
+++ b/crates/topos/src/components/regtest/mod.rs
@@ -5,7 +5,7 @@ use tokio::{
     spawn,
     sync::{mpsc, oneshot},
 };
-use topos_certificate_spammer::CertificateSpammerConfig;
+use topos_certificate_spammer::{error::Error, CertificateSpammerConfig};
 use tracing::{error, info};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 
@@ -65,7 +65,12 @@ pub(crate) async fn handle_command(
                             }
                         }
 
+                        if let Ok(Err(Error::BenchmarkConfig(ref msg))) = result {
+                            println!("Benchmark configuration error:\n{}", msg);
+                        }
+
                         if let Err(ref error) = result {
+
                             error!("Unable to execute network spam command due to: {error}");
                             std::process::exit(1);
                         }

--- a/crates/topos/src/components/regtest/mod.rs
+++ b/crates/topos/src/components/regtest/mod.rs
@@ -70,7 +70,8 @@ pub(crate) async fn handle_command(
                         }
 
                         if let Ok(Err(Error::BenchmarkConfig(ref msg))) = result {
-                            println!("Benchmark configuration error:\n{}", msg);
+                            error!("Benchmark configuration error:\n{}", msg);
+                            std::process::exit(1);
                         }
 
                         if let Err(ref error) = result {

--- a/crates/topos/src/components/regtest/mod.rs
+++ b/crates/topos/src/components/regtest/mod.rs
@@ -30,6 +30,9 @@ pub(crate) async fn handle_command(
                 nb_batches: cmd.nb_batches,
                 batch_interval: cmd.batch_interval,
                 target_subnets: cmd.target_subnets,
+                kubernetes: cmd.kubernetes,
+                dns: cmd.dns,
+                number: cmd.number,
             };
 
             // Setup instrumentation if both otlp agent and otlp service name

--- a/crates/topos/src/components/regtest/mod.rs
+++ b/crates/topos/src/components/regtest/mod.rs
@@ -30,7 +30,7 @@ pub(crate) async fn handle_command(
                 batch_interval: cmd.batch_interval,
                 target_subnets: cmd.target_subnets,
                 benchmark: cmd.benchmark,
-                hosts: cmd.hosts,
+                target_hosts: cmd.target_hosts,
                 number: cmd.number,
             };
 

--- a/crates/topos/tests/regtest.rs
+++ b/crates/topos/tests/regtest.rs
@@ -24,7 +24,7 @@ fn regtest_spam_invalid_hosts() -> Result<(), Box<dyn std::error::Error>> {
     cmd.arg("regtest")
         .arg("spam")
         .arg("--benchmark")
-        .arg("--hosts")
+        .arg("--target-hosts")
         .arg("asd")
         .arg("--number")
         .arg("1");
@@ -33,8 +33,9 @@ fn regtest_spam_invalid_hosts() -> Result<(), Box<dyn std::error::Error>> {
 
     let result: &str = std::str::from_utf8(&output.get_output().stdout)?;
 
-    assert!(result
-        .contains("Invalid hosts pattern. Has to be in the format of http://validator-1:9090"));
+    assert!(result.contains(
+        "Invalid target-hosts pattern. Has to be in the format of http://validator-1:9090"
+    ));
 
     Ok(())
 }
@@ -45,7 +46,7 @@ fn regtest_spam_invalid_number() -> Result<(), Box<dyn std::error::Error>> {
     cmd.arg("regtest")
         .arg("spam")
         .arg("--benchmark")
-        .arg("--hosts")
+        .arg("--target-hosts")
         .arg(" http://validator-{N}:9090")
         .arg("--number")
         .arg("dasd");

--- a/crates/topos/tests/regtest.rs
+++ b/crates/topos/tests/regtest.rs
@@ -17,3 +17,40 @@ fn regtest_spam_help_display() -> Result<(), Box<dyn std::error::Error>> {
 
     Ok(())
 }
+
+#[test]
+fn regtest_spam_invalid_hosts() -> Result<(), Box<dyn std::error::Error>> {
+    let mut cmd = Command::cargo_bin("topos")?;
+    cmd.arg("regtest")
+        .arg("spam")
+        .arg("--benchmark")
+        .arg("--hosts")
+        .arg("asd")
+        .arg("--number")
+        .arg("1");
+
+    let output = cmd.assert().failure();
+
+    let result: &str = std::str::from_utf8(&output.get_output().stdout)?;
+
+    assert!(result
+        .contains("Invalid hosts pattern. Has to be in the format of http://validator-1:9090"));
+
+    Ok(())
+}
+
+#[test]
+fn regtest_spam_invalid_number() -> Result<(), Box<dyn std::error::Error>> {
+    let mut cmd = Command::cargo_bin("topos")?;
+    cmd.arg("regtest")
+        .arg("spam")
+        .arg("--benchmark")
+        .arg("--hosts")
+        .arg(" http://validator-{N}:9090")
+        .arg("--number")
+        .arg("dasd");
+
+    cmd.assert().failure();
+
+    Ok(())
+}

--- a/crates/topos/tests/snapshots/regtest__regtest_spam_help_display.snap
+++ b/crates/topos/tests/snapshots/regtest__regtest_spam_help_display.snap
@@ -35,8 +35,8 @@ Options:
           Otlp service name. If not provided open telemetry will not be used [env: TOPOS_OTLP_SERVICE_NAME=]
       --benchmark
           Flag to indicate usage of Kubernetes [env: TOPOS_NETWORK_SPAMMER_BENCHMARK=]
-      --dns <DNS>
-          DNS template for generating target node addresses. e.g. `--dns="http://validator-{N}:1340"` [env: TOPOS_NETWORK_SPAMMER_DNS=]
+      --hosts <HOSTS>
+          DNS template for generating target node addresses. e.g. `--hosts="http://validator-{N}:1340"` [env: TOPOS_NETWORK_SPAMMER_HOSTS=]
       --number <NUMBER>
           Number of nodes to generate based on the DNS template [env: TOPOS_NETWORK_SPAMMER_NUMBER=]
   -h, --help

--- a/crates/topos/tests/snapshots/regtest__regtest_spam_help_display.snap
+++ b/crates/topos/tests/snapshots/regtest__regtest_spam_help_display.snap
@@ -35,8 +35,8 @@ Options:
           Otlp service name. If not provided open telemetry will not be used [env: TOPOS_OTLP_SERVICE_NAME=]
       --benchmark
           Flag to indicate usage of Kubernetes [env: TOPOS_NETWORK_SPAMMER_BENCHMARK=]
-      --hosts <HOSTS>
-          Template for generating target node entrypoints. e.g. `--hosts="http://validator-{N}:1340"` [env: TOPOS_NETWORK_SPAMMER_HOSTS=]
+      --target-hosts <TARGET_HOSTS>
+          Template for generating target node entrypoints. e.g. `--hosts="http://validator-{N}:1340"` [env: TOPOS_NETWORK_SPAMMER_TARGET_HOSTS=]
       --number <NUMBER>
           Number of nodes to generate based on the DNS template [env: TOPOS_NETWORK_SPAMMER_NUMBER=]
   -h, --help

--- a/crates/topos/tests/snapshots/regtest__regtest_spam_help_display.snap
+++ b/crates/topos/tests/snapshots/regtest__regtest_spam_help_display.snap
@@ -33,6 +33,12 @@ Options:
           Socket of the opentelemetry agent endpoint. If not provided open telemetry will not be used [env: TOPOS_OTLP_AGENT=]
       --otlp-service-name <OTLP_SERVICE_NAME>
           Otlp service name. If not provided open telemetry will not be used [env: TOPOS_OTLP_SERVICE_NAME=]
+      --kubernetes
+          Flag to indicate usage of Kubernetes [env: TOPOS_NETWORK_SPAMMER_KUBERNETES=]
+      --dns <DNS>
+          DNS template for generating target node addresses. e.g. `--dns="http://validator-{N}:1340"` [env: TOPOS_NETWORK_SPAMMER_DNS=]
+      --number <NUMBER>
+          Number of nodes to generate based on the DNS template [env: TOPOS_NETWORK_SPAMMER_NUMBER=]
   -h, --help
           Print help
 

--- a/crates/topos/tests/snapshots/regtest__regtest_spam_help_display.snap
+++ b/crates/topos/tests/snapshots/regtest__regtest_spam_help_display.snap
@@ -36,7 +36,7 @@ Options:
       --benchmark
           Flag to indicate usage of Kubernetes [env: TOPOS_NETWORK_SPAMMER_BENCHMARK=]
       --hosts <HOSTS>
-          DNS template for generating target node addresses. e.g. `--hosts="http://validator-{N}:1340"` [env: TOPOS_NETWORK_SPAMMER_HOSTS=]
+          Template for generating target node entrypoints. e.g. `--hosts="http://validator-{N}:1340"` [env: TOPOS_NETWORK_SPAMMER_HOSTS=]
       --number <NUMBER>
           Number of nodes to generate based on the DNS template [env: TOPOS_NETWORK_SPAMMER_NUMBER=]
   -h, --help

--- a/crates/topos/tests/snapshots/regtest__regtest_spam_help_display.snap
+++ b/crates/topos/tests/snapshots/regtest__regtest_spam_help_display.snap
@@ -33,8 +33,8 @@ Options:
           Socket of the opentelemetry agent endpoint. If not provided open telemetry will not be used [env: TOPOS_OTLP_AGENT=]
       --otlp-service-name <OTLP_SERVICE_NAME>
           Otlp service name. If not provided open telemetry will not be used [env: TOPOS_OTLP_SERVICE_NAME=]
-      --kubernetes
-          Flag to indicate usage of Kubernetes [env: TOPOS_NETWORK_SPAMMER_KUBERNETES=]
+      --benchmark
+          Flag to indicate usage of Kubernetes [env: TOPOS_NETWORK_SPAMMER_BENCHMARK=]
       --dns <DNS>
           DNS template for generating target node addresses. e.g. `--dns="http://validator-{N}:1340"` [env: TOPOS_NETWORK_SPAMMER_DNS=]
       --number <NUMBER>


### PR DESCRIPTION
# Description

When operating `topos` nodes in a Kubernetes environment, we have to address each service through a Kubernetes abstraction, called a `pod`. These pods are networked via `DNS`. When testing the network via `topos regtest spam` our fixed `IP_ADDRESS:PORT` approach of talking to each node doesn't work. We therefore add new flags to the command:

```
topos regtest spam --benchmark --dns "http://validator-{N}:1340" --number 10
```

Fixes [TP-852](https://linear.app/toposware/issue/TP-852/adjust-the-topos-regtest-spam-command-to-take-dns-instead-of-ip)

## PR Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
