### PR TITLE
feat: add proper error handling to setup command

### DIFF
--- a/crates/topos/src/components/setup/mod.rs
+++ b/crates/topos/src/components/setup/mod.rs
@@ -1,6 +1,5 @@
 use self::commands::{SetupCommand, SetupCommands};
 use tokio::{signal, spawn};
-use tracing::{error, info};
 
 use topos::{install_polygon_edge, list_polygon_edge_releases};
 
@@ -13,28 +12,28 @@ pub(crate) async fn handle_command(
         Some(SetupCommands::Subnet(cmd)) => {
             spawn(async move {
                 if cmd.list_releases {
-                    info!(
+                    println!(
                         "Retrieving release version list from repository: {}",
                         &cmd.repository
                     );
                     if let Err(e) = list_polygon_edge_releases(cmd.repository).await {
-                        error!("Error listing Polygon Edge release versions: {e}");
+                        eprintln!("Error listing Polygon Edge release versions: {e}");
                         std::process::exit(1);
                     } else {
                         std::process::exit(0);
                     }
                 } else {
-                    info!(
+                    println!(
                         "Starting installation of Polygon Edge binary to target path: {}",
                         &cmd.path.display()
                     );
                     if let Err(e) =
                         install_polygon_edge(cmd.repository, cmd.release, cmd.path.as_path()).await
                     {
-                        error!("Error installing Polygon Edge: {e}");
+                        eprintln!("Error installing Polygon Edge: {e}");
                         std::process::exit(1);
                     } else {
-                        info!("Polygon Edge installation successful");
+                        println!("Polygon Edge installation successful");
                         std::process::exit(0);
                     }
                 }
@@ -46,6 +45,9 @@ pub(crate) async fn handle_command(
 
             Ok(())
         }
-        None => Ok(()),
+        None => {
+            println!("No subcommand provided. You can use `--help` to see available subcommands.");
+            std::process::exit(1);
+        }
     }
 }

--- a/crates/topos/src/components/setup/mod.rs
+++ b/crates/topos/src/components/setup/mod.rs
@@ -24,6 +24,10 @@ pub(crate) async fn handle_command(
                         std::process::exit(0);
                     }
                 } else {
+                    info!(
+                        "Starting installation of Polygon Edge binary to target path: {}",
+                        &cmd.path.display()
+                    );
                     println!(
                         "Starting installation of Polygon Edge binary to target path: {}",
                         &cmd.path.display()
@@ -31,9 +35,11 @@ pub(crate) async fn handle_command(
                     if let Err(e) =
                         install_polygon_edge(cmd.repository, cmd.release, cmd.path.as_path()).await
                     {
+                        error!("Error installing Polygon Edge: {e}");
                         eprintln!("Error installing Polygon Edge: {e}");
                         std::process::exit(1);
                     } else {
+                        info!("Polygon Edge installation successful");
                         println!("Polygon Edge installation successful");
                         std::process::exit(0);
                     }
@@ -47,7 +53,8 @@ pub(crate) async fn handle_command(
             Ok(())
         }
         None => {
-            println!("No subcommand provided. You can use `--help` to see available subcommands.");
+            error!("No subcommand provided. You can use `--help` to see available subcommands.");
+            eprintln!("No subcommand provided. You can use `--help` to see available subcommands.");
             std::process::exit(1);
         }
     }

--- a/crates/topos/src/components/setup/mod.rs
+++ b/crates/topos/src/components/setup/mod.rs
@@ -1,5 +1,6 @@
 use self::commands::{SetupCommand, SetupCommands};
 use tokio::{signal, spawn};
+use tracing::{error, info};
 
 use topos::{install_polygon_edge, list_polygon_edge_releases};
 
@@ -12,12 +13,12 @@ pub(crate) async fn handle_command(
         Some(SetupCommands::Subnet(cmd)) => {
             spawn(async move {
                 if cmd.list_releases {
-                    println!(
+                    info!(
                         "Retrieving release version list from repository: {}",
                         &cmd.repository
                     );
                     if let Err(e) = list_polygon_edge_releases(cmd.repository).await {
-                        eprintln!("Error listing Polygon Edge release versions: {e}");
+                        error!("Error listing Polygon Edge release versions: {e}");
                         std::process::exit(1);
                     } else {
                         std::process::exit(0);

--- a/crates/topos/src/lib.rs
+++ b/crates/topos/src/lib.rs
@@ -15,7 +15,7 @@ pub enum Error {
     Http(reqwest::Error),
     #[error("Json parsing error: {0}")]
     InvalidJson(serde_json::Error),
-    #[error("There are no available release")]
+    #[error("There is no valid Polygon Edge release available")]
     NoValidRelease,
     #[error("Invalid release metadata")]
     InvalidReleaseMetadata,

--- a/crates/topos/tests/setup.rs
+++ b/crates/topos/tests/setup.rs
@@ -25,6 +25,21 @@ fn setup_subnet_install_edge() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test]
+fn setup_with_no_arguments() -> Result<(), Box<dyn std::error::Error>> {
+    let mut cmd = Command::cargo_bin("topos")?;
+    cmd.arg("setup");
+
+    let output = cmd.assert().failure();
+
+    let result: &str = std::str::from_utf8(&output.get_output().stdout)?;
+
+    assert!(result
+        .contains("No subcommand provided. You can use `--help` to see available subcommands."));
+
+    Ok(())
+}
+
+#[test]
 fn setup_subnet_fail_to_install_release() -> Result<(), Box<dyn std::error::Error>> {
     let tmp_home_dir = tempdir()?;
 

--- a/crates/topos/tests/setup.rs
+++ b/crates/topos/tests/setup.rs
@@ -1,0 +1,48 @@
+mod utils;
+
+use std::process::Command;
+
+use assert_cmd::prelude::*;
+use tempfile::tempdir;
+
+#[test]
+fn setup_subnet_install_edge() -> Result<(), Box<dyn std::error::Error>> {
+    let tmp_home_dir = tempdir()?;
+
+    let mut cmd = Command::cargo_bin("topos")?;
+    cmd.arg("setup")
+        .arg("subnet")
+        .arg("--path")
+        .arg(tmp_home_dir.path());
+
+    let output = cmd.assert().success();
+
+    let result: &str = std::str::from_utf8(&output.get_output().stdout)?;
+
+    assert!(result.contains("Polygon Edge installation successful"));
+
+    Ok(())
+}
+
+#[test]
+fn setup_subnet_fail_to_install_release() -> Result<(), Box<dyn std::error::Error>> {
+    let tmp_home_dir = tempdir()?;
+
+    let mut cmd = Command::cargo_bin("topos")?;
+    cmd.arg("setup")
+        .arg("subnet")
+        .arg("--path")
+        .arg(tmp_home_dir.path())
+        .arg("--release")
+        .arg("invalid");
+
+    let output = cmd.assert().failure();
+
+    let result: &str = std::str::from_utf8(&output.get_output().stderr)?;
+
+    assert!(result.contains(
+        "Error installing Polygon Edge: There is no valid Polygon Edge release available"
+    ));
+
+    Ok(())
+}

--- a/crates/topos/tests/setup.rs
+++ b/crates/topos/tests/setup.rs
@@ -31,7 +31,7 @@ fn setup_with_no_arguments() -> Result<(), Box<dyn std::error::Error>> {
 
     let output = cmd.assert().failure();
 
-    let result: &str = std::str::from_utf8(&output.get_output().stdout)?;
+    let result: &str = std::str::from_utf8(&output.get_output().stderr)?;
 
     assert!(result
         .contains("No subcommand provided. You can use `--help` to see available subcommands."));


### PR DESCRIPTION
# Description

Add more helpful CLI outputs to the `topos setup` command + tests.

Fixes [TP-863](https://linear.app/toposware/issue/TP-863/improve-output-of-the-topos-setup-command)
## PR Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
