### PR TITLE
feat: track queue size in metrics/graphql

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8188,6 +8188,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "topos-core",
+ "topos-metrics",
  "topos-test-sdk",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ strip = true
 [workspace.dependencies]
 topos-core = { path = "./crates/topos-core", default-features = false }
 topos-crypto = { path = "./crates/topos-crypto", default-features = false }
+topos-metrics = { path = "./crates/topos-metrics/", default-features = false }
 
 # Various utility crates
 clap = { version = "4.0", features = ["derive", "env", "string"] }

--- a/crates/topos-metrics/src/storage.rs
+++ b/crates/topos-metrics/src/storage.rs
@@ -1,6 +1,6 @@
 use prometheus::{
-    self, register_histogram_with_registry, register_int_counter_with_registry, Histogram,
-    IntCounter,
+    self, register_histogram_with_registry, register_int_counter_with_registry,
+    register_int_gauge_with_registry, Histogram, IntCounter, IntGauge,
 };
 
 use lazy_static::lazy_static;
@@ -31,4 +31,16 @@ lazy_static! {
             TOPOS_METRIC_REGISTRY
         )
         .unwrap();
+    pub static ref STORAGE_PENDING_POOL_COUNT: IntGauge = register_int_gauge_with_registry!(
+        "storage_pending_pool_count",
+        "Number of certificates in the pending pool.",
+        TOPOS_METRIC_REGISTRY
+    )
+    .unwrap();
+    pub static ref STORAGE_PRECEDENCE_POOL_COUNT: IntGauge = register_int_gauge_with_registry!(
+        "storage_precedence_pool_count",
+        "Number of certificates in the precedence pool.",
+        TOPOS_METRIC_REGISTRY
+    )
+    .unwrap();
 }

--- a/crates/topos-sequencer-subnet-runtime/tests/subnet_contract.rs
+++ b/crates/topos-sequencer-subnet-runtime/tests/subnet_contract.rs
@@ -321,7 +321,7 @@ async fn deploy_test_token(
         "Deploying new token {} with symbol {}",
         token_name, token_symbol
     );
-    match ierc20_messaging
+    let deploy_outcome = ierc20_messaging
         .deploy_token(token_encoded_params)
         .legacy()
         .gas(DEFAULT_GAS)
@@ -331,8 +331,9 @@ async fn deploy_test_token(
             error!("Unable deploy token: {e}");
             e
         })?
-        .await
-    {
+        .await;
+
+    match deploy_outcome {
         Ok(r) => {
             info!("Token deployed: {:?}", r);
         }

--- a/crates/topos-tce-storage/Cargo.toml
+++ b/crates/topos-tce-storage/Cargo.toml
@@ -8,6 +8,7 @@ workspace = true
 
 [dependencies]
 topos-core = { workspace = true, features = ["uci", "api"] }
+topos-metrics = { workspace = true }
 
 async-stream.workspace = true
 async-trait.workspace = true

--- a/crates/topos-tce-storage/src/errors.rs
+++ b/crates/topos-tce-storage/src/errors.rs
@@ -33,6 +33,9 @@ pub enum InternalStorageError {
     #[error("Invalid query argument: {0}")]
     InvalidQueryArgument(&'static str),
 
+    #[error("Unexpected DB state: {0}")]
+    UnexpectedDBState(&'static str),
+
     #[error(transparent)]
     Bincode(#[from] Box<bincode::ErrorKind>),
 

--- a/crates/topos-tce-storage/src/fullnode/mod.rs
+++ b/crates/topos-tce-storage/src/fullnode/mod.rs
@@ -3,6 +3,7 @@ use std::{collections::HashMap, sync::Arc};
 use arc_swap::ArcSwap;
 use async_trait::async_trait;
 
+use rocksdb::properties::ESTIMATE_NUM_KEYS;
 use topos_core::{
     types::{
         stream::{CertificateSourceStreamPosition, CertificateTargetStreamPosition, Position},
@@ -232,8 +233,11 @@ impl WriteStore for FullNodeStore {
 }
 
 impl ReadStore for FullNodeStore {
-    fn count_certificates_delivered(&self) -> Result<usize, StorageError> {
-        Ok(self.perpetual_tables.certificates.iter()?.count())
+    fn count_certificates_delivered(&self) -> Result<u64, StorageError> {
+        Ok(self
+            .perpetual_tables
+            .certificates
+            .property_int_value(ESTIMATE_NUM_KEYS)?)
     }
 
     fn get_source_head(&self, subnet_id: &SubnetId) -> Result<Option<SourceHead>, StorageError> {

--- a/crates/topos-tce-storage/src/store.rs
+++ b/crates/topos-tce-storage/src/store.rs
@@ -43,7 +43,7 @@ pub trait WriteStore: Send {
 /// [`FullNodeStore`](struct@super::fullnode::FullNodeStore) to read data.
 pub trait ReadStore: Send {
     /// Returns the number of certificates delivered
-    fn count_certificates_delivered(&self) -> Result<usize, StorageError>;
+    fn count_certificates_delivered(&self) -> Result<u64, StorageError>;
 
     /// Try to get a SourceHead of a subnet
     ///

--- a/crates/topos-tce-storage/src/tests/mod.rs
+++ b/crates/topos-tce-storage/src/tests/mod.rs
@@ -485,7 +485,7 @@ async fn get_source_head_for_subnet(store: Arc<ValidatorStore>) {
         create_certificate_chain(SOURCE_SUBNET_ID_1, &[TARGET_SUBNET_ID_2], 10);
 
     store
-        .insert_certificates_delivered(&expected_certificates_for_source_subnet_1)
+        .insert_certificates_delivered(&expected_certificates_for_source_subnet_1[..])
         .await
         .unwrap();
 
@@ -493,7 +493,7 @@ async fn get_source_head_for_subnet(store: Arc<ValidatorStore>) {
         create_certificate_chain(SOURCE_SUBNET_ID_2, &[TARGET_SUBNET_ID_2], 10);
 
     store
-        .insert_certificates_delivered(&expected_certificates_for_source_subnet_2)
+        .insert_certificates_delivered(&expected_certificates_for_source_subnet_2[..])
         .await
         .unwrap();
 

--- a/crates/topos-tce-storage/src/validator/mod.rs
+++ b/crates/topos-tce-storage/src/validator/mod.rs
@@ -22,6 +22,7 @@ use std::{
 
 use async_trait::async_trait;
 
+use rocksdb::properties::ESTIMATE_NUM_KEYS;
 use topos_core::{
     types::{
         stream::{CertificateSourceStreamPosition, Position},
@@ -29,7 +30,8 @@ use topos_core::{
     },
     uci::{Certificate, CertificateId, SubnetId, INITIAL_CERTIFICATE_ID},
 };
-use tracing::{debug, error, info, instrument};
+use topos_metrics::{STORAGE_PENDING_POOL_COUNT, STORAGE_PRECEDENCE_POOL_COUNT};
+use tracing::{debug, error, info, instrument, warn};
 
 use crate::{
     errors::{InternalStorageError, StorageError},
@@ -68,10 +70,35 @@ impl ValidatorStore {
         fullnode_store: Arc<FullNodeStore>,
     ) -> Result<Arc<Self>, StorageError> {
         let pending_tables: ValidatorPendingTables = ValidatorPendingTables::open(path);
+
         let store = Arc::new(Self {
             pending_tables,
             fullnode_store,
         });
+
+        let pending_count: i64 =
+            store
+                .count_pending_certificates()?
+                .try_into()
+                .map_err(|error| {
+                    warn!("Failed to convert estimate-num-keys to i64: {}", error);
+                    StorageError::InternalStorage(InternalStorageError::UnexpectedDBState(
+                        "Failed to convert estimate-num-keys to i64",
+                    ))
+                })?;
+
+        let precedence_count: i64 = store
+            .count_precedence_pool_certificates()?
+            .try_into()
+            .map_err(|error| {
+                warn!("Failed to convert estimate-num-keys to i64: {}", error);
+                StorageError::InternalStorage(InternalStorageError::UnexpectedDBState(
+                    "Failed to convert estimate-num-keys to i64",
+                ))
+            })?;
+
+        STORAGE_PENDING_POOL_COUNT.set(pending_count);
+        STORAGE_PRECEDENCE_POOL_COUNT.set(precedence_count);
 
         Ok(store)
     }
@@ -82,13 +109,19 @@ impl ValidatorStore {
     }
 
     /// Returns the number of certificates in the pending pool
-    pub fn count_pending_certificates(&self) -> Result<usize, StorageError> {
-        Ok(self.pending_tables.pending_pool.iter()?.count())
+    pub fn count_pending_certificates(&self) -> Result<u64, StorageError> {
+        Ok(self
+            .pending_tables
+            .pending_pool
+            .property_int_value(ESTIMATE_NUM_KEYS)?)
     }
 
     /// Returns the number of certificates in the precedence pool
-    pub fn count_precedence_pool_certificates(&self) -> Result<usize, StorageError> {
-        Ok(self.pending_tables.precedence_pool.iter()?.count())
+    pub fn count_precedence_pool_certificates(&self) -> Result<u64, StorageError> {
+        Ok(self
+            .pending_tables
+            .precedence_pool
+            .property_int_value(ESTIMATE_NUM_KEYS)?)
     }
 
     /// Try to return the [`PendingCertificateId`] for a [`CertificateId`]
@@ -171,7 +204,8 @@ impl ValidatorStore {
         Ok(result)
     }
 
-    pub fn insert_pending_certificates(
+    #[cfg(test)]
+    pub(crate) fn insert_pending_certificates(
         &self,
         certificates: &[Certificate],
     ) -> Result<Vec<PendingCertificateId>, StorageError> {
@@ -199,6 +233,8 @@ impl ValidatorStore {
         batch = batch.insert_batch(&self.pending_tables.pending_pool_index, index)?;
 
         batch.write()?;
+
+        STORAGE_PENDING_POOL_COUNT.add(ids.len() as i64);
 
         Ok(ids)
     }
@@ -243,6 +279,7 @@ impl ValidatorStore {
                 .pending_pool_index
                 .insert(&certificate.id, &id)?;
 
+            STORAGE_PENDING_POOL_COUNT.inc();
             debug!(
                 "Certificate {} is now in the pending pool at index: {}",
                 certificate.id, id
@@ -252,6 +289,8 @@ impl ValidatorStore {
             self.pending_tables
                 .precedence_pool
                 .insert(&certificate.prev_id, certificate)?;
+
+            STORAGE_PRECEDENCE_POOL_COUNT.inc();
             debug!(
                 "Certificate {} is now in the precedence pool, because the previous certificate \
                  {} isn't delivered yet",
@@ -424,6 +463,7 @@ impl ValidatorStore {
                 .pending_pool_index
                 .delete(&certificate.id)?;
 
+            STORAGE_PENDING_POOL_COUNT.dec();
             Ok(certificate)
         } else {
             Err(StorageError::InternalStorage(
@@ -435,7 +475,7 @@ impl ValidatorStore {
     }
 }
 impl ReadStore for ValidatorStore {
-    fn count_certificates_delivered(&self) -> Result<usize, StorageError> {
+    fn count_certificates_delivered(&self) -> Result<u64, StorageError> {
         self.fullnode_store.count_certificates_delivered()
     }
 
@@ -520,6 +560,12 @@ impl WriteStore for ValidatorStore {
             .get(&certificate.certificate.id)
         {
             _ = self.pending_tables.pending_pool.delete(&pending_id);
+            _ = self
+                .pending_tables
+                .pending_pool_index
+                .delete(&certificate.certificate.id);
+
+            STORAGE_PENDING_POOL_COUNT.dec();
         }
 
         if let Ok(Some(next_certificate)) = self
@@ -535,6 +581,9 @@ impl WriteStore for ValidatorStore {
             self.pending_tables
                 .precedence_pool
                 .delete(&certificate.certificate.id)?;
+
+            STORAGE_PRECEDENCE_POOL_COUNT.dec();
+            STORAGE_PENDING_POOL_COUNT.inc();
         }
 
         Ok(position)


### PR DESCRIPTION
# Description

This PR adds two new metrics accessible on the default port `3000` (e.g.: `localhost:3000`):

- `STORAGE_PENDING_POOL_COUNT` that tracks the number of certificates in the `pending_pool`.
- `STORAGE_PRECEDENCE_POOL_COUNT` that tracks the number of certificates in the `precedence_pool`.

:warning: Keep in my that those values are estimation based on the `rocksdb` metadata:

> Q: Why GetIntProperty can only returns an estimated number of keys in a RocksDB database?
>
> A: Obtaining an accurate number of keys in any LSM databases like RocksDB is a challenging problem as they have duplicate keys and deletion entries (i.e., tombstones) that will require a full compaction in order to get an accurate number of keys. In addition, if the RocksDB database contains merge operators, it will also make the estimated number of keys less accurate.


The `GraphQL` API is exposing those value under `getStoragePoolStats`.

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
