### PR TITLE
fix: add next_pending_certificate on end task

### DIFF
--- a/crates/topos-tce-broadcast/benches/task_manager.rs
+++ b/crates/topos-tce-broadcast/benches/task_manager.rs
@@ -56,7 +56,7 @@ pub async fn processing_double_echo(n: u64, validator_store: Arc<ValidatorStore>
         cmd_receiver,
         event_sender,
         double_echo_shutdown_receiver,
-        validator_store,
+        validator_store.clone(),
         broadcast_sender,
     );
 
@@ -82,7 +82,9 @@ pub async fn processing_double_echo(n: u64, validator_store: Arc<ValidatorStore>
         .collect::<Vec<_>>();
 
     for cert in &certificates {
-        double_echo.broadcast(cert.certificate.clone(), true).await;
+        _ = validator_store
+            .insert_pending_certificate(&cert.certificate)
+            .unwrap();
     }
 
     for cert in &certificates {

--- a/crates/topos-tce-broadcast/src/event.rs
+++ b/crates/topos-tce-broadcast/src/event.rs
@@ -34,6 +34,4 @@ pub enum ProtocolEvents {
         signature: Signature,
         validator_id: ValidatorId,
     },
-    /// For simulation purpose, for now only caused by ill-formed sampling
-    Die,
 }

--- a/crates/topos-tce-broadcast/src/task_manager/mod.rs
+++ b/crates/topos-tce-broadcast/src/task_manager/mod.rs
@@ -87,6 +87,9 @@ impl TaskManager {
         }
     }
 
+    /// Fetch the next pending certificates from the storage and create tasks for them.
+    /// This method is called periodically to check for new pending certificates and when
+    /// a task has finished.
     fn next_pending_certificate(&mut self) {
         debug!("Checking for next pending_certificates");
         match self.validator_store.get_next_pending_certificates(
@@ -199,6 +202,9 @@ impl TaskManager {
         }
     }
 
+    /// Create a new task for the given certificate and add it to the running tasks.
+    /// If the previous certificate is not available yet, the task will be created but not started.
+    /// This method is called when a pending certificate is fetched from the storage.
     fn create_task(&mut self, cert: &Certificate, need_gossip: bool) {
         match self.tasks.entry(cert.id) {
             std::collections::hash_map::Entry::Vacant(entry) => {

--- a/crates/topos-tce-broadcast/src/tests/task_manager.rs
+++ b/crates/topos-tce-broadcast/src/tests/task_manager.rs
@@ -7,6 +7,7 @@ use tokio::{
 };
 use tokio_util::sync::CancellationToken;
 use topos_crypto::{messages::MessageSigner, validator_id::ValidatorId};
+use topos_metrics::DOUBLE_ECHO_ACTIVE_TASKS_COUNT;
 use topos_tce_storage::validator::ValidatorStore;
 use topos_test_sdk::{
     certificates::create_certificate_chain,
@@ -80,4 +81,6 @@ async fn can_start(#[future] create_validator_store: Arc<ValidatorStore>) {
             cert: parent.certificate.clone(),
         })
         .await;
+
+    assert_eq!(DOUBLE_ECHO_ACTIVE_TASKS_COUNT.get(), 1);
 }

--- a/crates/topos-tce/src/app_context/protocol.rs
+++ b/crates/topos-tce/src/app_context/protocol.rs
@@ -80,9 +80,6 @@ impl AppContext {
             ProtocolEvents::AlreadyDelivered { certificate_id } => {
                 info!("Certificate {certificate_id} already delivered")
             }
-            ProtocolEvents::Die => {
-                error!("The DoubleEcho unexpectedly died, this is unrecoverable")
-            }
             _ => {}
         }
     }


### PR DESCRIPTION
# Description

This PR adds a call to `get_next_pending_certificates` after a task ends in order to process next pending certificates.
It also removes some old struct/mechanism of the broadcast.

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
