### PR TITLE
fix: remove duplicated certificate push on gossipsub

### DIFF
--- a/crates/topos-p2p/src/behaviour/gossip.rs
+++ b/crates/topos-p2p/src/behaviour/gossip.rs
@@ -76,7 +76,7 @@ impl Behaviour {
                 // Content based id
                 let mut s = DefaultHasher::new();
                 msg_id.data.hash(&mut s);
-                gossipsub::MessageId::from(s.finish().to_string())
+                gossipsub::MessageId::from(s.finish().to_be_bytes())
             })
             .build()
             .unwrap();

--- a/crates/topos-p2p/src/behaviour/gossip.rs
+++ b/crates/topos-p2p/src/behaviour/gossip.rs
@@ -1,3 +1,5 @@
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
 use std::{
     collections::{HashMap, HashSet, VecDeque},
     env,
@@ -35,7 +37,9 @@ impl Behaviour {
     ) -> Result<usize, &'static str> {
         match topic {
             TOPOS_GOSSIP => {
-                _ = self.gossipsub.publish(IdentTopic::new(topic), message);
+                if let Ok(msg_id) = self.gossipsub.publish(IdentTopic::new(topic), message) {
+                    debug!("Published on topos_gossip: {:?}", msg_id);
+                }
             }
             TOPOS_ECHO | TOPOS_READY => self.pending.entry(topic).or_default().push_back(message),
             _ => return Err("Invalid topic"),
@@ -68,6 +72,12 @@ impl Behaviour {
         let gossipsub = gossipsub::ConfigBuilder::default()
             .max_transmit_size(2 * 1024 * 1024)
             .validation_mode(gossipsub::ValidationMode::Strict)
+            .message_id_fn(|msg_id| {
+                // Content based id
+                let mut s = DefaultHasher::new();
+                msg_id.data.hash(&mut s);
+                gossipsub::MessageId::from(s.finish().to_string())
+            })
             .build()
             .unwrap();
 


### PR DESCRIPTION
# Description

The initial sender is supposed to be the only one to publish the Certificate on the gossipsub topic `topos_gossip`. The initial sender is the one who receives the Certificate from the gRPC API and not from gossipsub.

The rework on the storage by moving the management of the pending and precedence pool on the storage layer introduced the loss of the origin of the Certificate (whether it is received from gossipsub or grpc), consequently, the message was pushed by everyone on the `topos_gossip` topic on both cases since this storage rework.

## Additions and Changes

- Before (default config, see [here](https://docs.rs/libp2p-gossipsub/latest/libp2p_gossipsub/struct.Config.html#method.message_id))
  - Author based message id: `(PeerId, nonce)`, so we had as many duplicate of Certificate as the number of peers
- After
  - Content based message id: `hash(payload)`, consequently the other peers will detect the payload being the same, so it will not be published nor downloaded multiple times

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
