### PR TITLE
refactor: store instantiation

### DIFF
--- a/crates/topos-tce-storage/src/epoch/mod.rs
+++ b/crates/topos-tce-storage/src/epoch/mod.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::Path;
 use std::sync::Arc;
 use std::{collections::HashMap, sync::RwLock};
 
@@ -23,7 +23,7 @@ pub struct ValidatorPerEpochStore {
 }
 
 impl ValidatorPerEpochStore {
-    pub fn new(epoch_id: EpochId, path: PathBuf) -> Result<ArcSwap<Self>, StorageError> {
+    pub fn new(epoch_id: EpochId, path: &Path) -> Result<ArcSwap<Self>, StorageError> {
         let tables: ValidatorPerEpochTables = ValidatorPerEpochTables::open(epoch_id, path);
         let store = ArcSwap::from(Arc::new(Self {
             epoch_id,
@@ -42,7 +42,7 @@ pub struct EpochValidatorsStore {
 }
 
 impl EpochValidatorsStore {
-    pub fn new(path: PathBuf) -> Result<Arc<Self>, StorageError> {
+    pub fn new(path: &Path) -> Result<Arc<Self>, StorageError> {
         let tables = EpochValidatorsTables::open(path);
         let store = Arc::new(Self {
             tables,

--- a/crates/topos-tce-storage/src/epoch/tables.rs
+++ b/crates/topos-tce-storage/src/epoch/tables.rs
@@ -1,4 +1,4 @@
-use std::{fs::create_dir_all, path::PathBuf};
+use std::{fs::create_dir_all, path::Path};
 
 use rocksdb::ColumnFamilyDescriptor;
 use topos_core::uci::CertificateId;
@@ -19,8 +19,8 @@ pub struct EpochValidatorsTables {
 }
 
 impl EpochValidatorsTables {
-    pub(crate) fn open(mut path: PathBuf) -> Self {
-        path.push("validators");
+    pub(crate) fn open(path: &Path) -> Self {
+        let path = path.join("validators");
         let mut options = rocksdb::Options::default();
         options.create_if_missing(true);
         let db = init_db(&path, options).unwrap_or_else(|_| panic!("Cannot open DB at {:?}", path));
@@ -42,9 +42,8 @@ pub struct ValidatorPerEpochTables {
 }
 
 impl ValidatorPerEpochTables {
-    pub(crate) fn open(epoch_id: EpochId, mut path: PathBuf) -> Self {
-        path.push("epochs");
-        path.push(epoch_id.to_string());
+    pub(crate) fn open(epoch_id: EpochId, path: &Path) -> Self {
+        let path = path.join("epochs").join(epoch_id.to_string());
         if !path.exists() {
             warn!("Path {:?} does not exist, creating it", path);
             create_dir_all(&path).expect("Cannot create ValidatorPerEpochTables directory");

--- a/crates/topos-tce-storage/src/fullnode/mod.rs
+++ b/crates/topos-tce-storage/src/fullnode/mod.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, path::Path, sync::Arc};
 
 use arc_swap::ArcSwap;
 use async_trait::async_trait;
@@ -51,6 +51,22 @@ pub struct FullNodeStore {
 }
 
 impl FullNodeStore {
+    /// Try to create a new instance of [`FullNodeStore`] based on the given path
+    pub fn new(path: &Path) -> Result<Arc<Self>, StorageError> {
+        let perpetual_tables = Arc::new(ValidatorPerpetualTables::open(path));
+        let index_tables = Arc::new(IndexTables::open(path));
+
+        let validators_store = EpochValidatorsStore::new(path)?;
+
+        let epoch_store = ValidatorPerEpochStore::new(0, path)?;
+
+        FullNodeStore::open(
+            epoch_store,
+            validators_store,
+            perpetual_tables,
+            index_tables,
+        )
+    }
     pub fn open(
         epoch_store: ArcSwap<ValidatorPerEpochStore>,
         validators_store: Arc<EpochValidatorsStore>,

--- a/crates/topos-tce-storage/src/index/mod.rs
+++ b/crates/topos-tce-storage/src/index/mod.rs
@@ -1,4 +1,4 @@
-use std::{fs::create_dir_all, path::PathBuf};
+use std::{fs::create_dir_all, path::Path};
 
 use rocksdb::ColumnFamilyDescriptor;
 use topos_core::{
@@ -27,8 +27,8 @@ pub struct IndexTables {
 }
 
 impl IndexTables {
-    pub fn open(mut path: PathBuf) -> Self {
-        path.push("index");
+    pub fn open(path: &Path) -> Self {
+        let path = path.join("index");
         if !path.exists() {
             warn!("Path {:?} does not exist, creating it", path);
             create_dir_all(&path).expect("Cannot create IndexTables directory");

--- a/crates/topos-tce-storage/src/tests/support/mod.rs
+++ b/crates/topos-tce-storage/src/tests/support/mod.rs
@@ -40,14 +40,14 @@ pub(crate) fn database_name() -> &'static str {
 #[fixture]
 pub(crate) fn store() -> Arc<ValidatorStore> {
     let temp_dir = create_folder::default();
-    let perpetual_tables = Arc::new(ValidatorPerpetualTables::open(temp_dir.clone()));
-    let index_tables = Arc::new(IndexTables::open(temp_dir.clone()));
+    let perpetual_tables = Arc::new(ValidatorPerpetualTables::open(&temp_dir));
+    let index_tables = Arc::new(IndexTables::open(&temp_dir));
 
     let participants_store =
-        EpochValidatorsStore::new(temp_dir.clone()).expect("Unable to create Participant store");
+        EpochValidatorsStore::new(&temp_dir).expect("Unable to create Participant store");
 
     let epoch_store =
-        ValidatorPerEpochStore::new(0, temp_dir.clone()).expect("Unable to create Per epoch store");
+        ValidatorPerEpochStore::new(0, &temp_dir).expect("Unable to create Per epoch store");
 
     let store = FullNodeStore::open(
         epoch_store,
@@ -57,7 +57,7 @@ pub(crate) fn store() -> Arc<ValidatorStore> {
     )
     .expect("Unable to create full node store");
 
-    ValidatorStore::open(temp_dir, store).unwrap()
+    ValidatorStore::open(&temp_dir, store).unwrap()
 }
 
 #[fixture]

--- a/crates/topos-tce-storage/src/validator/mod.rs
+++ b/crates/topos-tce-storage/src/validator/mod.rs
@@ -16,7 +16,7 @@
 //!
 use std::{
     collections::HashMap,
-    path::PathBuf,
+    path::Path,
     sync::{atomic::Ordering, Arc},
 };
 
@@ -64,9 +64,16 @@ pub struct ValidatorStore {
 }
 
 impl ValidatorStore {
+    /// Try to create a new instance of [`ValidatorStore`] based on the given path
+    pub fn new(path: &Path) -> Result<Arc<Self>, StorageError> {
+        let fullnode_store = FullNodeStore::new(path)?;
+
+        Self::open(path, fullnode_store)
+    }
+
     /// Open a [`ValidatorStore`] at the given `path` and using the given [`FullNodeStore`]
     pub fn open(
-        path: PathBuf,
+        path: &Path,
         fullnode_store: Arc<FullNodeStore>,
     ) -> Result<Arc<Self>, StorageError> {
         let pending_tables: ValidatorPendingTables = ValidatorPendingTables::open(path);

--- a/crates/topos-tce-storage/src/validator/tables.rs
+++ b/crates/topos-tce-storage/src/validator/tables.rs
@@ -1,6 +1,6 @@
 use std::{
     fs::create_dir_all,
-    path::PathBuf,
+    path::Path,
     sync::atomic::{AtomicU64, Ordering},
 };
 
@@ -62,8 +62,8 @@ pub struct ValidatorPendingTables {
 
 impl ValidatorPendingTables {
     /// Open the [`ValidatorPendingTables`] at the given path.
-    pub fn open(mut path: PathBuf) -> Self {
-        path.push("pending");
+    pub fn open(path: &Path) -> Self {
+        let path = path.join("pending");
         if !path.exists() {
             warn!("Path {:?} does not exist, creating it", path);
             create_dir_all(&path).expect("Cannot create ValidatorPendingTables directory");
@@ -125,8 +125,8 @@ pub struct ValidatorPerpetualTables {
 }
 
 impl ValidatorPerpetualTables {
-    pub fn open(mut path: PathBuf) -> Self {
-        path.push("perpetual");
+    pub fn open(path: &Path) -> Self {
+        let path = path.join("perpetual");
         if !path.exists() {
             warn!("Path {:?} does not exist, creating it", path);
             create_dir_all(&path).expect("Cannot create ValidatorPerpetualTables directory");

--- a/crates/topos-test-sdk/src/storage/mod.rs
+++ b/crates/topos-test-sdk/src/storage/mod.rs
@@ -36,7 +36,7 @@ pub async fn create_validator_store(
     let fullnode_store = create_fullnode_store.await;
 
     let store =
-        ValidatorStore::open(temp_dir, fullnode_store).expect("Unable to create validator store");
+        ValidatorStore::open(&temp_dir, fullnode_store).expect("Unable to create validator store");
 
     store
         .insert_certificates_delivered(&certificates)
@@ -49,21 +49,22 @@ pub async fn create_validator_store(
 pub async fn create_validator_store_with_fullnode(
     fullnode_store: Arc<FullNodeStore>,
 ) -> Arc<ValidatorStore> {
-    ValidatorStore::open(create_folder::default(), fullnode_store)
+    ValidatorStore::open(&create_folder::default(), fullnode_store)
         .expect("Unable to create validator store")
 }
+
 #[fixture(certificates = Vec::new())]
 pub async fn create_fullnode_store(certificates: Vec<CertificateDelivered>) -> Arc<FullNodeStore> {
     let temp_dir = create_folder::default();
 
-    let perpetual_tables = Arc::new(ValidatorPerpetualTables::open(temp_dir.clone()));
-    let index_tables = Arc::new(IndexTables::open(temp_dir.clone()));
+    let perpetual_tables = Arc::new(ValidatorPerpetualTables::open(&temp_dir));
+    let index_tables = Arc::new(IndexTables::open(&temp_dir));
 
-    let validators_store = EpochValidatorsStore::new(temp_dir.clone())
-        .expect("Unable to create EpochValidators store");
+    let validators_store =
+        EpochValidatorsStore::new(&temp_dir).expect("Unable to create EpochValidators store");
 
     let epoch_store =
-        ValidatorPerEpochStore::new(0, temp_dir).expect("Unable to create Per epoch store");
+        ValidatorPerEpochStore::new(0, &temp_dir).expect("Unable to create Per epoch store");
 
     let store = FullNodeStore::open(
         epoch_store,


### PR DESCRIPTION
# Description

`ValidatorStore` is able to create the whole set of others stores. This PR is refactoring a bit how we access the `open` method to create the store.
Calling `new` with a single `path` will create the whole set of stores.

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
