### PR TITLE
feat: terminate stream if client is dropping the connection

### DIFF
--- a/crates/topos-tce-api/src/stream/mod.rs
+++ b/crates/topos-tce-api/src/stream/mod.rs
@@ -160,17 +160,16 @@ impl Stream {
                         Err(error) => {
                             match error.kind {
                                 StreamErrorKind::StreamClosed => {
-                                    // Currently, when the client is closing the connection,
-                                    // we don't receive a StreamClosed error. Further investigation is needed.
                                     warn!("Stream {} closed", self.stream_id);
-                                    break;
+                                    return Err(StreamError::new(self.stream_id, StreamErrorKind::StreamClosed));
                                 }
                                 _ => {
                                     // We are not handling specific errors for now.
                                     // If the sequencer is closing the connection, we are receiving a
                                     // StreamErrorKind::TransportError.
                                     error!( "Stream error: {:?}", error);
-                                    break;
+                                    return Err(StreamError::new(self.stream_id, error.kind));
+
                                 }
 
                             }

--- a/crates/topos-tce-api/src/stream/mod.rs
+++ b/crates/topos-tce-api/src/stream/mod.rs
@@ -150,6 +150,8 @@ impl Stream {
                     }
                 }
 
+                // We currently open the stream, but no other message from the client is getting processed.
+                // We are using this open connection to communicate `delivered_certificates` to the client.
                 stream_packet = self.inbound_stream.next() => {
                       if let Some(stream_packet) = stream_packet {
                           match stream_packet {
@@ -157,6 +159,7 @@ impl Stream {
                                     debug!("Received message for stream: {request_id:?}");
                                 }
                                 Err(error) => {
+                                    // In case the stream is getting closed from the client side for example
                                     error!("Stream error: {error:?}");
                                     break;
                                 }

--- a/crates/topos-tce-api/src/stream/mod.rs
+++ b/crates/topos-tce-api/src/stream/mod.rs
@@ -158,9 +158,17 @@ impl Stream {
                             debug!("Received message from stream_id: {:?}", self.stream_id);
                         }
                         Err(error) => {
-                            // In case the stream is getting closed from the client side for example
-                            error!("Stream closed! StreamId: {}", error.stream_id);
-                            break;
+                            match error.kind {
+                                StreamErrorKind::StreamClosed => {
+                                    warn!("Stream {} closed", self.stream_id);
+                                    break;
+                                }
+                                _ => {
+                                    error!( "Stream error: {:?}", error);
+                                    break;
+                                }
+
+                            }
                         }
                     }
                 }

--- a/crates/topos-tce-api/src/stream/mod.rs
+++ b/crates/topos-tce-api/src/stream/mod.rs
@@ -152,25 +152,29 @@ impl Stream {
 
                 // We currently open the stream, but no other message from the client is getting processed.
                 // We are using this open connection to communicate `delivered_certificates` to the client.
-                stream_packet = self.inbound_stream.next() => {
-                      if let Some(stream_packet) = stream_packet {
-                          match stream_packet {
-                                Ok((request_id, _message)) => {
-                                    debug!("Received message for stream: {request_id:?}");
-                                }
-                                Err(error) => {
-                                    // In case the stream is getting closed from the client side for example
-                                    error!("Stream error: {error:?}");
-                                    break;
-                                }
+                Some(stream_packet) = self.inbound_stream.next() => {
+                    match stream_packet {
+                        Ok((request_id, _message)) => {
+                            debug!("Received message for stream: {request_id:?}");
                         }
-                      } else {
-                          debug!("Stream is closed, exiting");
-                          break;
-                      }
+                        Err(error) => {
+                            // In case the stream is getting closed from the client side for example
+                            error!("Stream error: {error:?}");
+                            break;
+                        }
+                    }
                 }
+
+
+
+                // Some(_stream_packet) = self.inbound_stream.next() => {
+                //
+                // }
+
+                else => break,
             }
         }
+
         Ok(self.stream_id)
     }
 }

--- a/crates/topos-tce-api/src/stream/mod.rs
+++ b/crates/topos-tce-api/src/stream/mod.rs
@@ -159,17 +159,11 @@ impl Stream {
                         }
                         Err(error) => {
                             // In case the stream is getting closed from the client side for example
-                            error!("Stream error: {error:?}");
+                            error!("Stream closed! StreamId: {}", error.stream_id);
                             break;
                         }
                     }
                 }
-
-
-
-                // Some(_stream_packet) = self.inbound_stream.next() => {
-                //
-                // }
 
                 else => break,
             }

--- a/crates/topos-tce-api/src/stream/mod.rs
+++ b/crates/topos-tce-api/src/stream/mod.rs
@@ -154,8 +154,8 @@ impl Stream {
                 // We are using this open connection to communicate `delivered_certificates` to the client.
                 Some(stream_packet) = self.inbound_stream.next() => {
                     match stream_packet {
-                        Ok((request_id, _message)) => {
-                            debug!("Received message from stream_id: {request_id:?}");
+                        Ok((_request_id, _message)) => {
+                            debug!("Received message from stream_id: {:?}", self.stream_id);
                         }
                         Err(error) => {
                             // In case the stream is getting closed from the client side for example

--- a/crates/topos-tce-api/src/stream/mod.rs
+++ b/crates/topos-tce-api/src/stream/mod.rs
@@ -155,15 +155,20 @@ impl Stream {
                 Some(stream_packet) = self.inbound_stream.next() => {
                     match stream_packet {
                         Ok((_request_id, _message)) => {
-                            debug!("Received message from stream_id: {:?}", self.stream_id);
+                            trace!("Received message from stream_id: {:?}", self.stream_id);
                         }
                         Err(error) => {
                             match error.kind {
                                 StreamErrorKind::StreamClosed => {
+                                    // Currently, when the client is closing the connection,
+                                    // we don't receive a StreamClosed error. Further investigation is needed.
                                     warn!("Stream {} closed", self.stream_id);
                                     break;
                                 }
                                 _ => {
+                                    // We are not handling specific errors for now.
+                                    // If the sequencer is closing the connection, we are receiving a
+                                    // StreamErrorKind::TransportError.
                                     error!( "Stream error: {:?}", error);
                                     break;
                                 }

--- a/crates/topos-tce-api/src/stream/mod.rs
+++ b/crates/topos-tce-api/src/stream/mod.rs
@@ -155,7 +155,7 @@ impl Stream {
                 Some(stream_packet) = self.inbound_stream.next() => {
                     match stream_packet {
                         Ok((request_id, _message)) => {
-                            debug!("Received message for stream: {request_id:?}");
+                            debug!("Received message from stream_id: {request_id:?}");
                         }
                         Err(error) => {
                             // In case the stream is getting closed from the client side for example

--- a/crates/topos-tce-api/src/stream/mod.rs
+++ b/crates/topos-tce-api/src/stream/mod.rs
@@ -82,7 +82,7 @@ pub struct Stream {
     pub(crate) outbound_stream: Sender<Result<(Option<Uuid>, OutboundMessage), Status>>,
     /// gRPC inbound stream
     pub(crate) inbound_stream:
-    BoxStream<'static, Result<(Option<Uuid>, InboundMessage), StreamError>>,
+        BoxStream<'static, Result<(Option<Uuid>, InboundMessage), StreamError>>,
 }
 
 impl Debug for Stream {
@@ -215,11 +215,11 @@ impl Stream {
     async fn pre_start(&mut self) -> Result<(Option<Uuid>, TargetCheckpoint), StreamError> {
         let waiting_for_open_stream = async {
             if let Ok(Some((
-                               request_id,
-                               InboundMessage::OpenStream(OpenStream {
-                                                              target_checkpoint, ..
-                                                          }),
-                           ))) = self.inbound_stream.try_next().await
+                request_id,
+                InboundMessage::OpenStream(OpenStream {
+                    target_checkpoint, ..
+                }),
+            ))) = self.inbound_stream.try_next().await
             {
                 Ok((request_id, target_checkpoint))
             } else {


### PR DESCRIPTION
# Description

In our current setup, the `sequencer` is opening a gRPC stream to the `tce`. If successful, we send `delivered_certificates` back to the `sequencer` (or any other client). However, if `sequencer` shuts down (or restarts), the stream was not closed on the `tce` side, resulting in multiple open streams with dangling connections.

This PR is fixing this issue by handling the error cases of a streaming message.

Fixes [TP-500](https://linear.app/toposware/issue/TP-500/as-topos-i-want-to-better-manage-closed-grpc-streams-so-that-i-can)

## Result

```bash
024-02-23T15:55:02.245162Z  INFO topos_tce_api::stream: Received an OpenStream command for the stream cbb40b6a-89fc-497a-8594-fa680656bba1
2024-02-23T15:55:02.245189Z  INFO topos_tce_api::runtime: Stream cbb40b6a-89fc-497a-8594-fa680656bba1 is registered as subscriber

... 

2024-02-23T15:55:37.898530Z ERROR topos_tce_api::stream: Stream error: StreamError { stream_id: cbb40b6a-89fc-497a-8594-fa680656bba1, kind: Transport(Unknown) }
2024-02-23T15:55:37.898598Z  INFO topos_tce_api::runtime: Stream cbb40b6a-89fc-497a-8594-fa680656bba1 terminated gracefully
```

## Left ToDo

- [x] Check if we have to clean up the connection from `active_streams`
- [x] Check if we have to clean up any open channels
- [x] Testing


## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
