### PR TITLE
refactor: improve delivery timing

### DIFF
--- a/crates/topos-core/src/api/graphql/certificate.rs
+++ b/crates/topos-core/src/api/graphql/certificate.rs
@@ -20,6 +20,7 @@ pub struct CertificatePositions {
     source: SourceStreamPosition,
 }
 
+/// A certificate that has been delivered
 #[derive(Debug, Serialize, Deserialize, SimpleObject)]
 #[serde(rename_all = "camelCase")]
 pub struct Certificate {
@@ -36,6 +37,7 @@ pub struct Certificate {
     pub positions: CertificatePositions,
 }
 
+/// A certificate that has not been delivered yet
 #[derive(Debug, Serialize, Deserialize, SimpleObject)]
 #[serde(rename_all = "camelCase")]
 pub struct UndeliveredCertificate {

--- a/crates/topos-core/src/api/graphql/certificate.rs
+++ b/crates/topos-core/src/api/graphql/certificate.rs
@@ -53,7 +53,7 @@ pub struct UndeliveredCertificate {
     pub verifier: u32,
 }
 
-impl From<&crate::uci::Certificate> for UndeliveredCertificate {
+impl From<&uci::Certificate> for UndeliveredCertificate {
     fn from(value: &crate::uci::Certificate) -> Self {
         Self {
             id: CertificateId(value.id.to_string()),

--- a/crates/topos-core/src/api/graphql/certificate.rs
+++ b/crates/topos-core/src/api/graphql/certificate.rs
@@ -8,6 +8,12 @@ use super::{checkpoint::SourceStreamPosition, subnet::SubnetId};
 #[derive(Serialize, Deserialize, Debug, NewType)]
 pub struct CertificateId(String);
 
+impl From<uci::CertificateId> for CertificateId {
+    fn from(value: uci::CertificateId) -> Self {
+        Self(value.to_string())
+    }
+}
+
 #[derive(Serialize, Deserialize, Debug, SimpleObject)]
 #[serde(rename_all = "camelCase")]
 pub struct CertificatePositions {
@@ -28,6 +34,38 @@ pub struct Certificate {
     pub receipts_root_hash: String,
     pub verifier: u32,
     pub positions: CertificatePositions,
+}
+
+#[derive(Debug, Serialize, Deserialize, SimpleObject)]
+#[serde(rename_all = "camelCase")]
+pub struct UndeliveredCertificate {
+    pub id: CertificateId,
+    pub prev_id: CertificateId,
+    pub proof: String,
+    pub signature: String,
+    pub source_subnet_id: SubnetId,
+    pub state_root: String,
+    pub target_subnets: Vec<SubnetId>,
+    pub tx_root_hash: String,
+    pub receipts_root_hash: String,
+    pub verifier: u32,
+}
+
+impl From<&crate::uci::Certificate> for UndeliveredCertificate {
+    fn from(value: &crate::uci::Certificate) -> Self {
+        Self {
+            id: CertificateId(value.id.to_string()),
+            prev_id: CertificateId(value.prev_id.to_string()),
+            proof: hex::encode(&value.proof),
+            signature: hex::encode(&value.signature),
+            source_subnet_id: (&value.source_subnet_id).into(),
+            state_root: hex::encode(value.state_root),
+            target_subnets: value.target_subnets.iter().map(Into::into).collect(),
+            tx_root_hash: hex::encode(value.tx_root_hash),
+            receipts_root_hash: format!("0x{}", hex::encode(value.receipts_root_hash)),
+            verifier: value.verifier,
+        }
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize, SimpleObject)]
@@ -52,7 +90,7 @@ impl From<&CertificateDelivered> for Certificate {
             receipts_root_hash: format!("0x{}", hex::encode(uci_cert.receipts_root_hash)),
             verifier: uci_cert.verifier,
             positions: CertificatePositions {
-                source: (&value.proof_of_delivery.delivery_position).into(),
+                source: (&value.proof_of_delivery).into(),
             },
         }
     }

--- a/crates/topos-core/src/api/graphql/checkpoint.rs
+++ b/crates/topos-core/src/api/graphql/checkpoint.rs
@@ -1,7 +1,7 @@
 use async_graphql::{InputObject, SimpleObject};
 use serde::{Deserialize, Serialize};
 
-use crate::types::stream::CertificateSourceStreamPosition;
+use crate::types::ProofOfDelivery;
 
 use super::{certificate::CertificateId, subnet::SubnetId};
 
@@ -17,13 +17,15 @@ pub struct SourceStreamPositionInput {
 pub struct SourceStreamPosition {
     pub source_subnet_id: SubnetId,
     pub position: u64,
+    pub certificate_id: CertificateId,
 }
 
-impl From<&CertificateSourceStreamPosition> for SourceStreamPosition {
-    fn from(value: &CertificateSourceStreamPosition) -> Self {
+impl From<&ProofOfDelivery> for SourceStreamPosition {
+    fn from(value: &ProofOfDelivery) -> Self {
         Self {
-            source_subnet_id: (&value.subnet_id).into(),
-            position: *value.position,
+            certificate_id: value.certificate_id.into(),
+            source_subnet_id: (&value.delivery_position.subnet_id).into(),
+            position: *value.delivery_position.position,
         }
     }
 }

--- a/crates/topos-tce-api/src/graphql/builder.rs
+++ b/crates/topos-tce-api/src/graphql/builder.rs
@@ -14,13 +14,13 @@ use crate::{
     },
     runtime::InternalRuntimeCommand,
 };
-use topos_tce_storage::fullnode::FullNodeStore;
+use topos_tce_storage::validator::ValidatorStore;
 
 use super::query::SubscriptionRoot;
 
 #[derive(Default)]
 pub struct ServerBuilder {
-    store: Option<Arc<FullNodeStore>>,
+    store: Option<Arc<ValidatorStore>>,
     serve_addr: Option<SocketAddr>,
     runtime: Option<mpsc::Sender<InternalRuntimeCommand>>,
 }
@@ -34,7 +34,7 @@ impl ServerBuilder {
 
         self
     }
-    pub(crate) fn store(mut self, store: Arc<FullNodeStore>) -> Self {
+    pub(crate) fn store(mut self, store: Arc<ValidatorStore>) -> Self {
         self.store = Some(store);
 
         self
@@ -62,6 +62,7 @@ impl ServerBuilder {
             .take()
             .expect("Cannot build GraphQL server without a FullNode store");
 
+        let fulltnode_store = store.get_fullnode_store();
         let runtime = self
             .runtime
             .take()
@@ -69,6 +70,7 @@ impl ServerBuilder {
 
         let schema: ServiceSchema = Schema::build(QueryRoot, EmptyMutation, SubscriptionRoot)
             .data(store)
+            .data(fulltnode_store)
             .data(runtime)
             .finish();
 

--- a/crates/topos-tce-api/src/graphql/builder.rs
+++ b/crates/topos-tce-api/src/graphql/builder.rs
@@ -62,7 +62,7 @@ impl ServerBuilder {
             .take()
             .expect("Cannot build GraphQL server without a FullNode store");
 
-        let fulltnode_store = store.get_fullnode_store();
+        let fullnode_store = store.get_fullnode_store();
         let runtime = self
             .runtime
             .take()
@@ -70,7 +70,7 @@ impl ServerBuilder {
 
         let schema: ServiceSchema = Schema::build(QueryRoot, EmptyMutation, SubscriptionRoot)
             .data(store)
-            .data(fulltnode_store)
+            .data(fullnode_store)
             .data(runtime)
             .finish();
 

--- a/crates/topos-tce-api/src/graphql/query.rs
+++ b/crates/topos-tce-api/src/graphql/query.rs
@@ -5,6 +5,7 @@ use async_graphql::{Context, EmptyMutation, Object, Schema, Subscription};
 use async_trait::async_trait;
 use futures::{Stream, StreamExt};
 use tokio::sync::{mpsc, oneshot};
+use topos_core::api::graphql::certificate::UndeliveredCertificate;
 use topos_core::api::graphql::checkpoint::SourceStreamPosition;
 use topos_core::api::graphql::errors::GraphQLServerError;
 use topos_core::api::graphql::filter::SubnetFilter;
@@ -18,6 +19,7 @@ use topos_metrics::{STORAGE_PENDING_POOL_COUNT, STORAGE_PRECEDENCE_POOL_COUNT};
 use topos_tce_storage::fullnode::FullNodeStore;
 use topos_tce_storage::store::ReadStore;
 
+use topos_tce_storage::validator::ValidatorStore;
 use tracing::debug;
 
 use crate::runtime::InternalRuntimeCommand;
@@ -121,11 +123,43 @@ impl QueryRoot {
     /// The values are estimated as having a precise count is costly.
     async fn get_storage_pool_stats(
         &self,
-        _ctx: &Context<'_>,
+        ctx: &Context<'_>,
     ) -> Result<HashMap<&str, i64>, GraphQLServerError> {
         let mut stats = HashMap::new();
         stats.insert("pending_pool", STORAGE_PENDING_POOL_COUNT.get());
         stats.insert("precedence_pool", STORAGE_PRECEDENCE_POOL_COUNT.get());
+
+        let store = ctx.data::<Arc<ValidatorStore>>().map_err(|_| {
+            tracing::error!("Failed to get store from context");
+
+            GraphQLServerError::ParseDataConnector
+        })?;
+
+        stats.insert(
+            "pending_certificate_iter",
+            store
+                .get_pending_certificates()
+                .map_err(|_| GraphQLServerError::StorageError)?
+                .len() as i64,
+        );
+
+        stats.insert(
+            "iter_pending_certificate",
+            store
+                .iter_count_pending_certificates()
+                .map_err(|_| GraphQLServerError::StorageError)?
+                .try_into()
+                .unwrap_or(i64::MAX),
+        );
+
+        stats.insert(
+            "iter_precedence_certificate",
+            store
+                .iter_count_precedence_pool_certificates()
+                .map_err(|_| GraphQLServerError::StorageError)?
+                .try_into()
+                .unwrap_or(i64::MAX),
+        );
 
         Ok(stats)
     }
@@ -151,8 +185,51 @@ impl QueryRoot {
             .map(|(subnet_id, head)| SourceStreamPosition {
                 source_subnet_id: subnet_id.into(),
                 position: *head.position,
+                certificate_id: head.certificate_id.into(),
             })
             .collect())
+    }
+
+    /// This endpoint is used to get the current pending pool.
+    /// It returns [`CertificateId`] and the [`PendingCertificateId`]
+    async fn get_pending_pool(
+        &self,
+        ctx: &Context<'_>,
+    ) -> Result<HashMap<u64, CertificateId>, GraphQLServerError> {
+        let store = ctx.data::<Arc<ValidatorStore>>().map_err(|_| {
+            tracing::error!("Failed to get store from context");
+
+            GraphQLServerError::ParseDataConnector
+        })?;
+
+        Ok(store
+            .get_pending_certificates()
+            .map_err(|_| GraphQLServerError::StorageError)?
+            .iter()
+            .map(|(id, certificate)| (*id, certificate.id.into()))
+            .collect())
+    }
+
+    /// This endpoint is used to check if a certificate has any child certificate in the precedence pool.
+    async fn check_precedence(
+        &self,
+        ctx: &Context<'_>,
+        certificate_id: CertificateId,
+    ) -> Result<Option<UndeliveredCertificate>, GraphQLServerError> {
+        let store = ctx.data::<Arc<ValidatorStore>>().map_err(|_| {
+            tracing::error!("Failed to get store from context");
+
+            GraphQLServerError::ParseDataConnector
+        })?;
+
+        store
+            .check_precedence(
+                &certificate_id
+                    .try_into()
+                    .map_err(|_| GraphQLServerError::ParseCertificateId)?,
+            )
+            .map_err(|_| GraphQLServerError::StorageError)
+            .map(|certificate| certificate.as_ref().map(Into::into))
     }
 }
 

--- a/crates/topos-tce-api/src/graphql/tests.rs
+++ b/crates/topos-tce-api/src/graphql/tests.rs
@@ -131,6 +131,7 @@ async fn open_watch_certificate_delivered() {
                                   source {
                                     sourceSubnetId
                                     position
+                                    certificateId
                                   }
                                 }
                               }

--- a/crates/topos-tce-api/src/runtime/builder.rs
+++ b/crates/topos-tce-api/src/runtime/builder.rs
@@ -118,7 +118,6 @@ impl RuntimeBuilder {
                 .store(
                     self.store
                         .take()
-                        .map(|store| store.get_fullnode_store())
                         .expect("Unable to build GraphQL Server, Store is missing"),
                 )
                 .runtime(internal_runtime_command_sender.clone())

--- a/crates/topos-tce-api/src/runtime/error.rs
+++ b/crates/topos-tce-api/src/runtime/error.rs
@@ -16,4 +16,7 @@ pub enum RuntimeError {
 
     #[error("Unexpected store error: {0}")]
     Store(#[from] StorageError),
+
+    #[error("Communication error: {0}")]
+    CommunicationError(String),
 }

--- a/crates/topos-tce-api/tests/runtime.rs
+++ b/crates/topos-tce-api/tests/runtime.rs
@@ -583,6 +583,7 @@ async fn can_query_graphql_endpoint_for_certificates(
                   source {{
                     sourceSubnetId
                     position
+                    certificateId
                   }}
                 }}
             }}

--- a/crates/topos-tce-api/tests/runtime.rs
+++ b/crates/topos-tce-api/tests/runtime.rs
@@ -675,8 +675,8 @@ async fn check_storage_pool_stats(
 
     #[derive(Debug, Deserialize)]
     struct PoolStats {
-        pending_pool: u64,
-        precedence_pool: u64,
+        metrics_pending_pool: u64,
+        metrics_precedence_pool: u64,
     }
 
     let client = reqwest::Client::new();
@@ -693,8 +693,14 @@ async fn check_storage_pool_stats(
         .await
         .unwrap();
 
-    assert_eq!(response.data.get_storage_pool_stats.pending_pool, 10);
-    assert_eq!(response.data.get_storage_pool_stats.precedence_pool, 200);
+    assert_eq!(
+        response.data.get_storage_pool_stats.metrics_pending_pool,
+        10
+    );
+    assert_eq!(
+        response.data.get_storage_pool_stats.metrics_precedence_pool,
+        200
+    );
 }
 
 #[rstest]
@@ -713,7 +719,7 @@ async fn get_pending_pool(
     let fullnode_store = create_fullnode_store::default().await;
 
     let store: Arc<ValidatorStore> =
-        create_validator_store(vec![], futures::future::ready(fullnode_store.clone())).await;
+        create_validator_store(&[], futures::future::ready(fullnode_store.clone())).await;
 
     for certificate in &certificates {
         _ = store.insert_pending_certificate(&certificate.certificate);
@@ -791,7 +797,7 @@ async fn check_precedence(
     let fullnode_store = create_fullnode_store::default().await;
 
     let store: Arc<ValidatorStore> =
-        create_validator_store(vec![], futures::future::ready(fullnode_store.clone())).await;
+        create_validator_store(&[], futures::future::ready(fullnode_store.clone())).await;
 
     for certificate in &certificates {
         _ = store.insert_pending_certificate(&certificate.certificate);

--- a/crates/topos-tce-api/tests/runtime.rs
+++ b/crates/topos-tce-api/tests/runtime.rs
@@ -1,6 +1,8 @@
 use futures::Stream;
 use rstest::rstest;
 use serde::Deserialize;
+use std::collections::HashMap;
+use std::sync::Arc;
 use std::time::Duration;
 use test_log::test;
 use tokio::sync::{broadcast, mpsc};
@@ -13,6 +15,7 @@ use topos_core::api::grpc::shared::v1::checkpoints::TargetCheckpoint;
 use topos_core::api::grpc::shared::v1::positions::TargetStreamPosition;
 use topos_core::types::stream::Position;
 use topos_core::types::CertificateDelivered;
+use topos_core::uci::CertificateId;
 use topos_core::{
     api::grpc::tce::v1::{
         api_service_client::ApiServiceClient,
@@ -24,6 +27,7 @@ use topos_core::{
 use topos_metrics::{STORAGE_PENDING_POOL_COUNT, STORAGE_PRECEDENCE_POOL_COUNT};
 use topos_tce_api::{Runtime, RuntimeEvent};
 use topos_tce_storage::types::CertificateDeliveredWithPositions;
+use topos_tce_storage::validator::ValidatorStore;
 use topos_tce_storage::StorageClient;
 use topos_test_sdk::certificates::{
     create_certificate, create_certificate_at_position, create_certificate_chain,
@@ -691,4 +695,86 @@ async fn check_storage_pool_stats(
 
     assert_eq!(response.data.get_storage_pool_stats.pending_pool, 10);
     assert_eq!(response.data.get_storage_pool_stats.precedence_pool, 200);
+}
+
+#[rstest]
+#[timeout(Duration::from_secs(4))]
+#[test(tokio::test)]
+async fn get_pending_pool(
+    broadcast_stream: broadcast::Receiver<CertificateDeliveredWithPositions>,
+) {
+    let addr = get_available_addr();
+    let graphql_addr = get_available_addr();
+    let metrics_addr = get_available_addr();
+
+    // launch data store
+    let certificates = create_certificate_chain(SOURCE_SUBNET_ID_1, &[TARGET_SUBNET_ID_1], 15);
+
+    let fullnode_store = create_fullnode_store::default().await;
+
+    let store: Arc<ValidatorStore> =
+        create_validator_store(vec![], futures::future::ready(fullnode_store.clone())).await;
+
+    for certificate in &certificates {
+        _ = store.insert_pending_certificate(&certificate.certificate);
+    }
+
+    let storage_client = StorageClient::new(store.clone());
+
+    let (_runtime_client, _launcher, _ctx) = Runtime::builder()
+        .with_broadcast_stream(broadcast_stream)
+        .storage(storage_client)
+        .store(store)
+        .serve_grpc_addr(addr)
+        .serve_graphql_addr(graphql_addr)
+        .serve_metrics_addr(metrics_addr)
+        .build_and_launch()
+        .await;
+
+    // Wait for server to boot
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let query = format!(
+        r#"
+        query {{ getPendingPool }}
+        "#
+    );
+
+    #[derive(Debug, Deserialize)]
+    struct Response {
+        data: PendingPool,
+    }
+
+    #[derive(Debug, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct PendingPool {
+        #[serde(rename = "getPendingPool")]
+        pool: HashMap<u64, String>,
+    }
+
+    let client = reqwest::Client::new();
+
+    let mut response = client
+        .post(format!("http://{}", graphql_addr))
+        .json(&serde_json::json!({
+            "query": query,
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json::<Response>()
+        .await
+        .unwrap();
+
+    assert_eq!(response.data.pool.len(), 1);
+    let first: CertificateId = response
+        .data
+        .pool
+        .remove(&1)
+        .unwrap()
+        .as_bytes()
+        .try_into()
+        .unwrap();
+
+    assert_eq!(first, certificates[0].certificate.id);
 }

--- a/crates/topos-tce-broadcast/src/double_echo/mod.rs
+++ b/crates/topos-tce-broadcast/src/double_echo/mod.rs
@@ -137,6 +137,12 @@ impl DoubleEcho {
 
                         command if self.subscriptions.is_some() => {
                             match command {
+                                DoubleEchoCommand::Broadcast { cert, need_gossip, pending_id } => {
+                                    _ = self
+                                        .task_manager_message_sender
+                                        .send(DoubleEchoCommand::Broadcast { need_gossip, cert, pending_id })
+                                        .await;
+                                    }
                                 DoubleEchoCommand::Echo { certificate_id, validator_id, signature } => {
                                     // Check if source is part of known_validators
                                     if !self.validators.contains(&validator_id) {
@@ -173,7 +179,6 @@ impl DoubleEcho {
 
                                     self.handle_ready(certificate_id, validator_id, signature).await
                                 },
-                                _ => {}
                             }
 
                         },

--- a/crates/topos-tce-broadcast/src/lib.rs
+++ b/crates/topos-tce-broadcast/src/lib.rs
@@ -88,6 +88,7 @@ pub enum DoubleEchoCommand {
     Broadcast {
         need_gossip: bool,
         cert: Certificate,
+        pending_id: u64,
     },
 
     /// When echo reply received

--- a/crates/topos-tce-broadcast/src/tests/task_manager.rs
+++ b/crates/topos-tce-broadcast/src/tests/task_manager.rs
@@ -65,6 +65,7 @@ async fn can_start(#[future] create_validator_store: Arc<ValidatorStore>) {
         .send(crate::DoubleEchoCommand::Broadcast {
             need_gossip: false,
             cert: child.certificate.clone(),
+            pending_id: 0,
         })
         .await;
 
@@ -72,6 +73,7 @@ async fn can_start(#[future] create_validator_store: Arc<ValidatorStore>) {
         .send(crate::DoubleEchoCommand::Broadcast {
             need_gossip: false,
             cert: parent.certificate.clone(),
+            pending_id: 0,
         })
         .await;
 
@@ -79,6 +81,7 @@ async fn can_start(#[future] create_validator_store: Arc<ValidatorStore>) {
         .send(crate::DoubleEchoCommand::Broadcast {
             need_gossip: false,
             cert: parent.certificate.clone(),
+            pending_id: 0,
         })
         .await;
 

--- a/crates/topos-tce-storage/src/client.rs
+++ b/crates/topos-tce-storage/src/client.rs
@@ -35,7 +35,7 @@ impl StorageClient {
     pub async fn get_pending_certificates(
         &self,
     ) -> Result<Vec<(PendingCertificateId, Certificate)>, StorageError> {
-        self.store.get_pending_certificates()
+        Ok(self.store.iter_pending_pool()?.collect())
     }
 
     pub async fn fetch_certificates(

--- a/crates/topos-tce-storage/src/tests/mod.rs
+++ b/crates/topos-tce-storage/src/tests/mod.rs
@@ -640,7 +640,7 @@ async fn get_pending_certificates(store: Arc<ValidatorStore>) {
         )
         .unwrap();
 
-    let pending_certificates = store.get_pending_certificates().unwrap();
+    let pending_certificates = store.iter_pending_pool().unwrap().collect::<Vec<_>>();
     assert_eq!(
         expected_pending_certificates.len(),
         pending_certificates.len()
@@ -654,7 +654,7 @@ async fn get_pending_certificates(store: Arc<ValidatorStore>) {
     let cert_to_remove = expected_pending_certificates.remove(8);
     store.delete_pending_certificate(&cert_to_remove.0).unwrap();
 
-    let pending_certificates = store.get_pending_certificates().unwrap();
+    let pending_certificates = store.iter_pending_pool().unwrap().collect::<Vec<_>>();
     assert_eq!(
         expected_pending_certificates.len(),
         pending_certificates.len()

--- a/crates/topos-tce-storage/src/validator/mod.rs
+++ b/crates/topos-tce-storage/src/validator/mod.rs
@@ -212,6 +212,7 @@ impl ValidatorStore {
             .collect())
     }
 
+    /// Returns the [Certificate] (if any) that is currently in the precedence pool for the given [CertificateId]
     pub fn check_precedence(
         &self,
         certificate_id: &CertificateId,

--- a/crates/topos-tce-storage/src/validator/mod.rs
+++ b/crates/topos-tce-storage/src/validator/mod.rs
@@ -138,12 +138,34 @@ impl ValidatorStore {
             .property_int_value(ESTIMATE_NUM_KEYS)?)
     }
 
+    /// Returns the number of certificates in the pending pool (by iterating)
+    pub fn iter_count_pending_certificates(&self) -> Result<u64, StorageError> {
+        Ok(self
+            .pending_tables
+            .pending_pool
+            .iter()?
+            .count()
+            .try_into()
+            .unwrap_or(u64::MAX))
+    }
+
     /// Returns the number of certificates in the precedence pool
     pub fn count_precedence_pool_certificates(&self) -> Result<u64, StorageError> {
         Ok(self
             .pending_tables
             .precedence_pool
             .property_int_value(ESTIMATE_NUM_KEYS)?)
+    }
+
+    /// Returns the number of certificates in the precedence pool (by iterating)
+    pub fn iter_count_precedence_pool_certificates(&self) -> Result<u64, StorageError> {
+        Ok(self
+            .pending_tables
+            .precedence_pool
+            .iter()?
+            .count()
+            .try_into()
+            .unwrap_or(u64::MAX))
     }
 
     /// Try to return the [`PendingCertificateId`] for a [`CertificateId`]
@@ -188,6 +210,13 @@ impl ValidatorStore {
             .iter_at(from)?
             .take(number)
             .collect())
+    }
+
+    pub fn check_precedence(
+        &self,
+        certificate_id: &CertificateId,
+    ) -> Result<Option<Certificate>, StorageError> {
+        Ok(self.pending_tables.precedence_pool.get(certificate_id)?)
     }
 
     // TODO: Performance issue on this one as we iter over all the pending certificates

--- a/crates/topos-tce/src/app_context.rs
+++ b/crates/topos-tce/src/app_context.rs
@@ -162,13 +162,13 @@ impl AppContext {
 
         let pending_certificates = self
             .validator_store
-            .count_pending_certificates()
+            .pending_pool_size()
             .map_err(|error| format!("Unable to count pending certificates: {error}"))
             .unwrap();
 
         let precedence_pool_certificates = self
             .validator_store
-            .count_precedence_pool_certificates()
+            .precedence_pool_size()
             .map_err(|error| format!("Unable to count precedence pool certificates: {error}"))
             .unwrap();
 

--- a/crates/topos-tce/src/app_context/network.rs
+++ b/crates/topos-tce/src/app_context/network.rs
@@ -43,11 +43,21 @@ impl AppContext {
                             );
 
                             match self.validator_store.insert_pending_certificate(&cert) {
-                                Ok(Some(_)) => {
+                                Ok(Some(pending_id)) => {
                                     debug!(
                                         "Certificate {} has been inserted into pending pool",
                                         cert.id
                                     );
+
+                                    _ = self
+                                        .tce_cli
+                                        .get_double_echo_channel()
+                                        .send(DoubleEchoCommand::Broadcast {
+                                            need_gossip: false,
+                                            cert,
+                                            pending_id,
+                                        })
+                                        .await;
                                 }
                                 Ok(None) => {
                                     debug!(

--- a/crates/topos-tce/src/lib.rs
+++ b/crates/topos-tce/src/lib.rs
@@ -116,11 +116,11 @@ pub async fn run(
         .map_err(|error| format!("Unable to count certificates delivered: {error}"))?;
 
     let pending_certificates = validator_store
-        .count_pending_certificates()
+        .pending_pool_size()
         .map_err(|error| format!("Unable to count pending certificates: {error}"))?;
 
     let precedence_pool_certificates = validator_store
-        .count_precedence_pool_certificates()
+        .precedence_pool_size()
         .map_err(|error| format!("Unable to count precedence pool certificates: {error}"))?;
 
     info!(


### PR DESCRIPTION
# Description

This PR refactors a bit the workflow that trigger new certs for delivery.
It also adds new queries on GraphQL in order to extract context from nodes.

Previous refactorization introduced  `pull` mechanism on the `broadcast` where the `task` manager where actively pulling the next `certificate` from the `pending_pool`, the setup was to allow the broadcast to start consuming the `pending_pool` when ready. However, a corner case exists that this PR is solving:

- `pending_pool` checking tick is 10sec (1sec in reality) and tick at `S0`
- `certificate A` arrives on the node, is valid and can be delivered at `S2`
- ...
- `pending_pool` checking tick execute at `S10`
- `certificate A` is being broadcast

Between `S2` and `S10` the certificate is waiting in the pending_pool for nothing.

The changes are modifying this and do:

- `pending_pool` checking tick is 10sec (1sec in reality) and tick at `S0`
- `certificate A` arrives on the node, is valid and can be delivered at `S2`
- A `broadcast` command is sent to the `task manager` at `S2`, the task manager check the precedence of the certificate and see that the parent is delivered
- `certificate A` is being broadcast
- ...
- `pending_pool` checking tick execute at `S10`

## Next / Questions / Options

- The `pending_pool` tick could be set to a lower value or even switched to a proper channel between the `pending_pool` and the `task_manager`

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
