### PR TITLE
fix: concurrency insert between pending and delivered

### DIFF
--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -37,7 +37,7 @@ jobs:
           workflow_file_name: topos:integration-tests.yml
           ref: main
           wait_interval: 60
-          client_payload: '{ "topos-docker-tag": "${{ env.docker_tag }}" }'
+          client_payload: '{ "topos-docker-tag": "${{ env.docker_tag }}", "topos-smart-contracts-docker-tag": "3.2.0" }'
 
   frontend-erc20-e2e:
     runs-on: ubuntu-latest
@@ -59,4 +59,4 @@ jobs:
           workflow_file_name: frontend:erc20-messaging.yml
           ref: main
           wait_interval: 60
-          client_payload: '{ "topos-docker-tag": "${{ env.docker_tag }}" }'
+          client_payload: '{ "topos-docker-tag": "${{ env.docker_tag }}", "topos-smart-contracts-docker-tag": "3.2.0" }'

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -37,7 +37,7 @@ jobs:
           workflow_file_name: topos:integration-tests.yml
           ref: main
           wait_interval: 60
-          client_payload: '{ "topos-docker-tag": "${{ env.docker_tag }}", "topos-smart-contracts-docker-tag": "3.2.0", "local-erc20-messaging-infra-ref": "fix/fixing-configuration-addr" }'
+          client_payload: '{ "topos-docker-tag": "${{ env.docker_tag }}" }'
 
   frontend-erc20-e2e:
     runs-on: ubuntu-latest
@@ -59,4 +59,4 @@ jobs:
           workflow_file_name: frontend:erc20-messaging.yml
           ref: main
           wait_interval: 60
-          client_payload: '{ "topos-docker-tag": "${{ env.docker_tag }}", "topos-smart-contracts-docker-tag": "3.2.0", "local-erc20-messaging-infra-ref": "fix/fixing-configuration-addr"}'
+          client_payload: '{ "topos-docker-tag": "${{ env.docker_tag }}" }'

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -37,7 +37,7 @@ jobs:
           workflow_file_name: topos:integration-tests.yml
           ref: main
           wait_interval: 60
-          client_payload: '{ "topos-docker-tag": "${{ env.docker_tag }}", "topos-smart-contracts-docker-tag": "3.2.0" }'
+          client_payload: '{ "topos-docker-tag": "${{ env.docker_tag }}", "topos-smart-contracts-docker-tag": "3.2.0", "local-erc20-messaging-infra-ref": "fix/fixing-configuration-addr" }'
 
   frontend-erc20-e2e:
     runs-on: ubuntu-latest
@@ -59,4 +59,4 @@ jobs:
           workflow_file_name: frontend:erc20-messaging.yml
           ref: main
           wait_interval: 60
-          client_payload: '{ "topos-docker-tag": "${{ env.docker_tag }}", "topos-smart-contracts-docker-tag": "3.2.0"}'
+          client_payload: '{ "topos-docker-tag": "${{ env.docker_tag }}", "topos-smart-contracts-docker-tag": "3.2.0", "local-erc20-messaging-infra-ref": "fix/fixing-configuration-addr"}'

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -37,7 +37,7 @@ jobs:
           workflow_file_name: topos:integration-tests.yml
           ref: main
           wait_interval: 60
-          client_payload: '{ "topos-docker-tag": "${{ env.docker_tag }}" }'
+          client_payload: '{ "topos-docker-tag": "${{ env.docker_tag }}", "topos-smart-contracts-docker-tag": "3.2.0" }'
 
   frontend-erc20-e2e:
     runs-on: ubuntu-latest
@@ -59,4 +59,4 @@ jobs:
           workflow_file_name: frontend:erc20-messaging.yml
           ref: main
           wait_interval: 60
-          client_payload: '{ "topos-docker-tag": "${{ env.docker_tag }}" }'
+          client_payload: '{ "topos-docker-tag": "${{ env.docker_tag }}", "topos-smart-contracts-docker-tag": "3.2.0"}'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3731,6 +3731,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ip_network"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa2f047c0a98b2f299aa5d6d7088443570faae494e9ae1305e48be000c9e0eb1"
+
+[[package]]
 name = "ipconfig"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8015,6 +8021,7 @@ dependencies = [
  "http-body 0.4.6",
  "http-body-util",
  "hyper 0.14.28",
+ "ip_network",
  "lazy_static",
  "libp2p",
  "libp2p-swarm-test",

--- a/crates/topos-p2p/Cargo.toml
+++ b/crates/topos-p2p/Cargo.toml
@@ -36,6 +36,7 @@ hyper.workspace = true
 prost.workspace = true
 
 topos-core = { path = "../topos-core/" }
+ip_network = "0.4.1"
 
 [dev-dependencies]
 libp2p-swarm-test = "0.3.0"

--- a/crates/topos-p2p/src/behaviour/gossip.rs
+++ b/crates/topos-p2p/src/behaviour/gossip.rs
@@ -255,7 +255,7 @@ impl NetworkBehaviour for Behaviour {
                     _ => {}
                 },
                 gossipsub::Event::Subscribed { peer_id, topic } => {
-                    debug!("Subscribed to {:?} with {peer_id}", topic);
+                    debug!("{peer_id} subscribed to {:?}", topic);
 
                     // If the behaviour isn't already healthy we check if this event
                     // triggers a switch to healthy
@@ -268,7 +268,7 @@ impl NetworkBehaviour for Behaviour {
                     }
                 }
                 gossipsub::Event::Unsubscribed { peer_id, topic } => {
-                    debug!("Unsubscribed from {:?} with {peer_id}", topic);
+                    debug!("{peer_id} unsubscribed from {:?}", topic);
                 }
                 gossipsub::Event::GossipsubNotSupported { peer_id } => {
                     debug!("Gossipsub not supported by {:?}", peer_id);

--- a/crates/topos-p2p/src/behaviour/peer_info.rs
+++ b/crates/topos-p2p/src/behaviour/peer_info.rs
@@ -11,8 +11,7 @@ pub struct PeerInfoBehaviour {
 
 impl PeerInfoBehaviour {
     pub(crate) fn new(identify_protocol: &'static str, peer_key: &Keypair) -> PeerInfoBehaviour {
-        let ident_config = IdentifyConfig::new(identify_protocol.to_string(), peer_key.public())
-            .with_push_listen_addr_updates(true);
+        let ident_config = IdentifyConfig::new(identify_protocol.to_string(), peer_key.public());
 
         let identify = Identify::new(ident_config);
 

--- a/crates/topos-p2p/src/config.rs
+++ b/crates/topos-p2p/src/config.rs
@@ -6,6 +6,7 @@ pub struct NetworkConfig {
     pub discovery: DiscoveryConfig,
     pub yamux_max_buffer_size: usize,
     pub yamux_window_size: Option<u32>,
+    pub allow_private_ip: bool,
 }
 
 impl Default for NetworkConfig {
@@ -16,6 +17,7 @@ impl Default for NetworkConfig {
             discovery: Default::default(),
             yamux_max_buffer_size: usize::MAX,
             yamux_window_size: None,
+            allow_private_ip: false,
         }
     }
 }

--- a/crates/topos-p2p/src/network.rs
+++ b/crates/topos-p2p/src/network.rs
@@ -87,6 +87,13 @@ impl<'a> NetworkBuilder<'a> {
         self
     }
 
+    #[doc(hidden)]
+    pub fn allow_private_ip(mut self, allow_private_ip: bool) -> Self {
+        self.config.allow_private_ip = allow_private_ip;
+
+        self
+    }
+
     pub fn store(mut self, store: MemoryStore) -> Self {
         self.store = Some(store);
 

--- a/crates/topos-p2p/src/runtime/handle_event.rs
+++ b/crates/topos-p2p/src/runtime/handle_event.rs
@@ -193,6 +193,7 @@ impl EventHandler<SwarmEvent<ComposedEvent>> for Runtime {
         let behaviour = self.swarm.behaviour();
 
         if let Some(event) = self.healthy_status_changed() {
+            debug!("Healthy status changed: {:?}", event);
             _ = self.event_sender.send(event).await;
         }
 

--- a/crates/topos-tce-api/src/graphql/builder.rs
+++ b/crates/topos-tce-api/src/graphql/builder.rs
@@ -62,7 +62,7 @@ impl ServerBuilder {
             .take()
             .expect("Cannot build GraphQL server without a FullNode store");
 
-        let fullnode_store = store.get_fullnode_store();
+        let fullnode_store = store.fullnode_store();
         let runtime = self
             .runtime
             .take()

--- a/crates/topos-tce-api/tests/grpc/certificate_precedence.rs
+++ b/crates/topos-tce-api/tests/grpc/certificate_precedence.rs
@@ -33,11 +33,13 @@ async fn fetch_latest_pending_certificates() {
 
     assert!(validator_store
         .insert_pending_certificate(&certificates[1].certificate)
+        .await
         .unwrap()
         .is_none());
 
     assert!(validator_store
         .insert_pending_certificate(&certificates[0].certificate)
+        .await
         .unwrap()
         .is_some());
 
@@ -82,12 +84,14 @@ async fn fetch_latest_pending_certificates_with_conflicts() {
     for certificate in certificates.iter().skip(1) {
         assert!(validator_store
             .insert_pending_certificate(&certificate.certificate)
+            .await
             .unwrap()
             .is_none());
     }
 
     assert!(validator_store
         .insert_pending_certificate(&certificates[0].certificate)
+        .await
         .unwrap()
         .is_some());
 

--- a/crates/topos-tce-api/tests/runtime.rs
+++ b/crates/topos-tce-api/tests/runtime.rs
@@ -722,7 +722,9 @@ async fn get_pending_pool(
         create_validator_store(&[], futures::future::ready(fullnode_store.clone())).await;
 
     for certificate in &certificates {
-        _ = store.insert_pending_certificate(&certificate.certificate);
+        _ = store
+            .insert_pending_certificate(&certificate.certificate)
+            .await;
     }
 
     let storage_client = StorageClient::new(store.clone());
@@ -800,7 +802,9 @@ async fn check_precedence(
         create_validator_store(&[], futures::future::ready(fullnode_store.clone())).await;
 
     for certificate in &certificates {
-        _ = store.insert_pending_certificate(&certificate.certificate);
+        _ = store
+            .insert_pending_certificate(&certificate.certificate)
+            .await;
     }
 
     let storage_client = StorageClient::new(store.clone());

--- a/crates/topos-tce-broadcast/benches/task_manager.rs
+++ b/crates/topos-tce-broadcast/benches/task_manager.rs
@@ -84,6 +84,7 @@ pub async fn processing_double_echo(n: u64, validator_store: Arc<ValidatorStore>
     for cert in &certificates {
         _ = validator_store
             .insert_pending_certificate(&cert.certificate)
+            .await
             .unwrap();
     }
 

--- a/crates/topos-tce-broadcast/src/tests/mod.rs
+++ b/crates/topos-tce-broadcast/src/tests/mod.rs
@@ -16,6 +16,7 @@ use topos_tce_storage::validator::ValidatorStore;
 use topos_test_sdk::constants::*;
 use topos_test_sdk::storage::create_validator_store;
 
+mod task;
 mod task_manager;
 
 const CHANNEL_SIZE: usize = 10;

--- a/crates/topos-tce-broadcast/src/tests/mod.rs
+++ b/crates/topos-tce-broadcast/src/tests/mod.rs
@@ -189,6 +189,7 @@ async fn trigger_success_path_upon_reaching_threshold(#[case] params: TceParams)
     _ = ctx
         .validator_store
         .insert_pending_certificate(&dummy_cert)
+        .await
         .unwrap();
 
     assert!(matches!(
@@ -243,6 +244,7 @@ async fn trigger_ready_when_reached_enough_ready(#[case] params: TceParams) {
     _ = ctx
         .validator_store
         .insert_pending_certificate(&dummy_cert)
+        .await
         .unwrap();
 
     assert!(matches!(

--- a/crates/topos-tce-broadcast/src/tests/task.rs
+++ b/crates/topos-tce-broadcast/src/tests/task.rs
@@ -1,4 +1,4 @@
-use std::{future::IntoFuture, str::FromStr, sync::Arc, time::Duration};
+use std::{future::IntoFuture, sync::Arc, time::Duration};
 
 use rstest::rstest;
 use tokio::{
@@ -11,6 +11,7 @@ use topos_tce_storage::validator::ValidatorStore;
 use topos_test_sdk::{
     certificates::create_certificate_chain,
     constants::{SOURCE_SUBNET_ID_1, TARGET_SUBNET_ID_1},
+    crypto::message_signer,
     storage::create_validator_store,
 };
 
@@ -26,6 +27,7 @@ async fn start_with_ungossiped_cert(
     #[future(awt)]
     #[from(create_validator_store)]
     validatore_store: Arc<ValidatorStore>,
+    message_signer: Arc<MessageSigner>,
 ) {
     let certificate = create_certificate_chain(SOURCE_SUBNET_ID_1, &[TARGET_SUBNET_ID_1], 1)
         .pop()
@@ -40,10 +42,6 @@ async fn start_with_ungossiped_cert(
     };
     let (event_sender, mut event_receiver) = mpsc::channel(2);
     let (broadcast_sender, _) = broadcast::channel(1);
-    let message_signer = Arc::new(
-        MessageSigner::from_str("122f3ae6ade1fd136b292cea4f6243c7811160352c8821528547a1fe7c459daf")
-            .unwrap(),
-    );
     let need_gossip = true;
     let subscriptions = SubscriptionsView::default();
 

--- a/crates/topos-tce-broadcast/src/tests/task.rs
+++ b/crates/topos-tce-broadcast/src/tests/task.rs
@@ -1,0 +1,86 @@
+use std::{future::IntoFuture, str::FromStr, sync::Arc, time::Duration};
+
+use rstest::rstest;
+use tokio::{
+    spawn,
+    sync::{broadcast, mpsc},
+};
+use topos_core::uci::Certificate;
+use topos_crypto::{messages::MessageSigner, validator_id::ValidatorId};
+use topos_tce_storage::validator::ValidatorStore;
+use topos_test_sdk::{
+    certificates::create_certificate_chain,
+    constants::{SOURCE_SUBNET_ID_1, TARGET_SUBNET_ID_1},
+    storage::create_validator_store,
+};
+
+use crate::{
+    double_echo::broadcast_state::BroadcastState, event::ProtocolEvents,
+    sampler::SubscriptionsView, task_manager::task::Task,
+};
+
+#[rstest]
+#[test_log::test(tokio::test)]
+#[timeout(Duration::from_secs(1))]
+async fn start_with_ungossiped_cert(
+    #[future(awt)]
+    #[from(create_validator_store)]
+    validatore_store: Arc<ValidatorStore>,
+) {
+    let certificate = create_certificate_chain(SOURCE_SUBNET_ID_1, &[TARGET_SUBNET_ID_1], 1)
+        .pop()
+        .unwrap()
+        .certificate;
+    let certificate_id = certificate.id;
+    let validator_id = ValidatorId::default();
+    let thresholds = topos_config::tce::broadcast::ReliableBroadcastParams {
+        echo_threshold: 1,
+        ready_threshold: 1,
+        delivery_threshold: 1,
+    };
+    let (event_sender, mut event_receiver) = mpsc::channel(2);
+    let (broadcast_sender, _) = broadcast::channel(1);
+    let message_signer = Arc::new(
+        MessageSigner::from_str("122f3ae6ade1fd136b292cea4f6243c7811160352c8821528547a1fe7c459daf")
+            .unwrap(),
+    );
+    let need_gossip = true;
+    let subscriptions = SubscriptionsView::default();
+
+    let broadcast_state = BroadcastState::new(
+        certificate,
+        validator_id,
+        thresholds.echo_threshold,
+        thresholds.ready_threshold,
+        thresholds.delivery_threshold,
+        event_sender,
+        subscriptions,
+        need_gossip,
+        message_signer,
+    );
+
+    let (task, _ctx) = Task::new(
+        certificate_id,
+        broadcast_state,
+        validatore_store,
+        broadcast_sender,
+    );
+
+    let _handle = spawn(task.into_future());
+
+    let event = event_receiver.recv().await;
+    assert!(matches!(
+            event,
+        Some(ProtocolEvents::Broadcast {
+            certificate_id: id
+        }) if id == certificate_id
+    ));
+
+    let event = event_receiver.recv().await;
+    assert!(matches!(
+            event,
+        Some(ProtocolEvents::Gossip {
+            cert: Certificate { id, .. }
+        }) if id == certificate_id
+    ));
+}

--- a/crates/topos-tce-broadcast/src/tests/task_manager.rs
+++ b/crates/topos-tce-broadcast/src/tests/task_manager.rs
@@ -1,4 +1,4 @@
-use std::{str::FromStr, sync::Arc};
+use std::sync::Arc;
 
 use rstest::rstest;
 use tokio::{
@@ -12,6 +12,7 @@ use topos_tce_storage::validator::ValidatorStore;
 use topos_test_sdk::{
     certificates::create_certificate_chain,
     constants::{SOURCE_SUBNET_ID_1, TARGET_SUBNET_ID_1},
+    crypto::message_signer,
     storage::create_validator_store,
 };
 
@@ -23,6 +24,7 @@ async fn can_start(
     #[future(awt)]
     #[from(create_validator_store)]
     validator_store: Arc<ValidatorStore>,
+    message_signer: Arc<MessageSigner>,
 ) {
     let (message_sender, message_receiver) = mpsc::channel(1);
     let (event_sender, _) = mpsc::channel(1);
@@ -34,11 +36,6 @@ async fn can_start(
         ready_threshold: 1,
         delivery_threshold: 1,
     };
-
-    let message_signer = Arc::new(
-        MessageSigner::from_str("122f3ae6ade1fd136b292cea4f6243c7811160352c8821528547a1fe7c459daf")
-            .unwrap(),
-    );
 
     let manager = TaskManager::new(
         message_receiver,

--- a/crates/topos-tce-broadcast/src/tests/task_manager.rs
+++ b/crates/topos-tce-broadcast/src/tests/task_manager.rs
@@ -19,8 +19,11 @@ use crate::{sampler::SubscriptionsView, task_manager::TaskManager};
 
 #[rstest]
 #[tokio::test]
-async fn can_start(#[future] create_validator_store: Arc<ValidatorStore>) {
-    let validator_store = create_validator_store.await;
+async fn can_start(
+    #[future(awt)]
+    #[from(create_validator_store)]
+    validator_store: Arc<ValidatorStore>,
+) {
     let (message_sender, message_receiver) = mpsc::channel(1);
     let (event_sender, _) = mpsc::channel(1);
     let (broadcast_sender, _) = broadcast::channel(1);

--- a/crates/topos-tce-storage/src/fullnode/mod.rs
+++ b/crates/topos-tce-storage/src/fullnode/mod.rs
@@ -85,7 +85,7 @@ impl FullNodeStore {
     }
 
     /// Await for a [`LockGuards`] for the given certificate id
-    pub(crate) async fn get_certificate_lock_guard(
+    pub(crate) async fn certificate_lock_guard(
         &self,
         certificate_id: CertificateId,
     ) -> OwnedMutexGuard<()> {
@@ -97,7 +97,7 @@ impl FullNodeStore {
     }
 
     /// Await for a [`LockGuards`] for the given subnet id
-    pub(crate) async fn get_subnet_lock_guard(&self, subnet_id: SubnetId) -> OwnedMutexGuard<()> {
+    pub(crate) async fn subnet_lock_guard(&self, subnet_id: SubnetId) -> OwnedMutexGuard<()> {
         self.subnet_lock_guards
             .get_lock(subnet_id)
             .await
@@ -114,11 +114,11 @@ impl WriteStore for FullNodeStore {
     ) -> Result<CertificatePositions, StorageError> {
         // Lock resources for concurrency issues
         let _cert_guard = self
-            .get_certificate_lock_guard(certificate.certificate.id)
+            .certificate_lock_guard(certificate.certificate.id)
             .await;
 
         let _subnet_guard = self
-            .get_subnet_lock_guard(certificate.certificate.source_subnet_id)
+            .subnet_lock_guard(certificate.certificate.source_subnet_id)
             .await;
 
         let subnet_id = certificate.certificate.source_subnet_id;

--- a/crates/topos-tce-storage/src/fullnode/mod.rs
+++ b/crates/topos-tce-storage/src/fullnode/mod.rs
@@ -84,6 +84,7 @@ impl FullNodeStore {
         }))
     }
 
+    /// Await for a [`LockGuards`] for the given certificate id
     pub(crate) async fn get_certificate_lock_guard(
         &self,
         certificate_id: CertificateId,
@@ -95,6 +96,7 @@ impl FullNodeStore {
             .await
     }
 
+    /// Await for a [`LockGuards`] for the given subnet id
     pub(crate) async fn get_subnet_lock_guard(&self, subnet_id: SubnetId) -> OwnedMutexGuard<()> {
         self.subnet_lock_guards
             .get_lock(subnet_id)

--- a/crates/topos-tce-storage/src/tests/mod.rs
+++ b/crates/topos-tce-storage/src/tests/mod.rs
@@ -33,12 +33,12 @@ const TARGET_STORAGE_SUBNET_ID_1: SubnetId = TARGET_SUBNET_ID_1;
 const TARGET_STORAGE_SUBNET_ID_2: SubnetId = TARGET_SUBNET_ID_2;
 
 #[rstest]
-#[test]
-fn can_persist_a_pending_certificate(store: Arc<ValidatorStore>) {
+#[tokio::test]
+async fn can_persist_a_pending_certificate(store: Arc<ValidatorStore>) {
     let certificate =
         Certificate::new_with_default_fields(PREV_CERTIFICATE_ID, SOURCE_SUBNET_ID_1, &[]).unwrap();
 
-    assert!(store.insert_pending_certificate(&certificate).is_ok());
+    assert!(store.insert_pending_certificate(&certificate).await.is_ok());
 }
 
 #[rstest]
@@ -285,6 +285,7 @@ async fn pending_certificate_are_removed_during_persist_action(store: Arc<Valida
     let certificate_id = certificate.id;
     let pending_id = store
         .insert_pending_certificate(&certificate)
+        .await
         .unwrap()
         .unwrap();
 
@@ -452,6 +453,7 @@ async fn pending_certificate_can_be_removed(store: Arc<ValidatorStore>) {
 
     let pending_id = store
         .insert_pending_certificate(&certificate)
+        .await
         .unwrap()
         .unwrap();
 
@@ -462,11 +464,12 @@ async fn pending_certificate_can_be_removed(store: Arc<ValidatorStore>) {
 
     let pending_id = store
         .insert_pending_certificate(&certificate)
+        .await
         .unwrap()
         .unwrap();
 
     assert!(matches!(
-        store.insert_pending_certificate(&certificate),
+        store.insert_pending_certificate(&certificate).await,
         Err(StorageError::InternalStorage(
             crate::errors::InternalStorageError::CertificateAlreadyPending
         ))

--- a/crates/topos-tce-storage/src/tests/pending_certificates.rs
+++ b/crates/topos-tce-storage/src/tests/pending_certificates.rs
@@ -1,9 +1,9 @@
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use rstest::rstest;
 use topos_core::uci::{Certificate, INITIAL_CERTIFICATE_ID};
 use topos_test_sdk::{
-    certificates::create_certificate_at_position,
+    certificates::{create_certificate_at_position, create_certificate_chain},
     constants::{SOURCE_SUBNET_ID_1, TARGET_SUBNET_ID_1},
 };
 
@@ -11,7 +11,8 @@ use super::support::store;
 use crate::{store::WriteStore, validator::ValidatorStore};
 
 #[rstest]
-fn adding_genesis_pending_certificate(store: Arc<ValidatorStore>) {
+#[tokio::test]
+async fn adding_genesis_pending_certificate(store: Arc<ValidatorStore>) {
     let certificate = Certificate::new_with_default_fields(
         INITIAL_CERTIFICATE_ID,
         SOURCE_SUBNET_ID_1,
@@ -21,6 +22,7 @@ fn adding_genesis_pending_certificate(store: Arc<ValidatorStore>) {
 
     let pending_id = store
         .insert_pending_certificate(&certificate)
+        .await
         .unwrap()
         .unwrap();
 
@@ -49,6 +51,7 @@ async fn adding_pending_certificate_with_precedence_check_fail(store: Arc<Valida
 
     assert!(store
         .insert_pending_certificate(&certificate)
+        .await
         .unwrap()
         .is_none());
 
@@ -84,5 +87,128 @@ async fn adding_pending_certificate_already_delivered(store: Arc<ValidatorStore>
 
     assert!(store
         .insert_pending_certificate(&initial_certificate_delivered.certificate)
+        .await
         .is_err());
+}
+
+/// This test is covering a corner case which involve the delivery of a prev certificate
+/// and a child certificate.
+///
+/// The scenario is this one:
+/// - A `prev` certificate (`C1`) has been delivered (by the broadcast) and need to be persisted
+///   The persist method will hold a lock while performing multiple insert/delete to avoid
+///   insert race condition.
+/// - At the same time, another node is sending a certificate (`C2`) which have `C1` as `prev_id`.
+///   `C2` is looking at the storage to find if the `prev_id` `C1` is delivered but find nothing as
+///   the `persist` method is still working at creating the `WriteBatch`. It led the node to put
+///   `C2` in the `precedence_pool` waiting for `C1` to be delivered while it is in fact already
+///   delivered.
+///
+/// To avoid that and as a first step, when trying to insert a certificate in the pending pool,
+/// The node will try to acquire a lock guard on the certificate but also on the prev_id.
+mod concurrency {
+    use crate::errors::StorageError;
+
+    use super::*;
+
+    #[rstest]
+    #[tokio::test]
+    async fn adding_pending_certificate_but_prev_fail(store: Arc<ValidatorStore>) {
+        let mut certs = create_certificate_chain(SOURCE_SUBNET_ID_1, &[TARGET_SUBNET_ID_1], 2);
+        let cert = certs.pop().unwrap();
+        let parent = certs.pop().unwrap();
+
+        assert!(certs.is_empty());
+
+        // The lock guard simulate the start of the certificate insertion in the table.
+        let lock_guard_certificate = store
+            .fullnode_store
+            .get_certificate_lock_guard(parent.certificate.id)
+            .await;
+
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            // Drop the lock_guard of the prev_id without inserting it
+            drop(lock_guard_certificate);
+        });
+
+        assert!(matches!(
+            store.insert_pending_certificate(&cert.certificate).await,
+            Ok(None)
+        ));
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn certificate_in_delivery(store: Arc<ValidatorStore>) {
+        let mut certs = create_certificate_chain(SOURCE_SUBNET_ID_1, &[TARGET_SUBNET_ID_1], 1);
+        let cert = certs.pop().unwrap();
+
+        assert!(certs.is_empty());
+
+        // The lock guard simulate the start of the certificate insertion in the table.
+        let lock_guard_subnet = store
+            .fullnode_store
+            .get_subnet_lock_guard(cert.certificate.source_subnet_id)
+            .await;
+
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(200)).await;
+            // Drop the lock_guard of the certificate without inserting it
+            drop(lock_guard_subnet);
+        });
+
+        let store_deliver = store.clone();
+        let delivered = cert.clone();
+        tokio::spawn(async move {
+            _ = store_deliver
+                .insert_certificate_delivered(&delivered)
+                .await
+                .unwrap();
+        });
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert!(matches!(
+            store.insert_pending_certificate(&cert.certificate).await,
+            Err(StorageError::InternalStorage(
+                crate::errors::InternalStorageError::CertificateAlreadyExists
+            ))
+        ));
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn prev_certificate_in_delivery(store: Arc<ValidatorStore>) {
+        let mut certs = create_certificate_chain(SOURCE_SUBNET_ID_1, &[TARGET_SUBNET_ID_1], 2);
+        let cert = certs.pop().unwrap();
+        let prev = certs.pop().unwrap();
+
+        assert!(certs.is_empty());
+
+        // The lock guard simulate the start of the certificate insertion in the table.
+        let lock_guard_subnet = store
+            .fullnode_store
+            .get_subnet_lock_guard(cert.certificate.source_subnet_id)
+            .await;
+
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(200)).await;
+            // Drop the lock_guard of the certificate without inserting it
+            drop(lock_guard_subnet);
+        });
+
+        let store_deliver = store.clone();
+        tokio::spawn(async move {
+            _ = store_deliver
+                .insert_certificate_delivered(&prev)
+                .await
+                .unwrap();
+        });
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert!(matches!(
+            store.insert_pending_certificate(&cert.certificate).await,
+            Ok(Some(_))
+        ));
+    }
 }

--- a/crates/topos-tce-storage/src/tests/pending_certificates.rs
+++ b/crates/topos-tce-storage/src/tests/pending_certificates.rs
@@ -91,7 +91,7 @@ async fn adding_pending_certificate_already_delivered(store: Arc<ValidatorStore>
         .is_err());
 }
 
-/// This test is covering a corner case which involve the delivery of a prev certificate
+/// This test is covering a corner case which involves the delivery of a prev certificate
 /// and a child certificate.
 ///
 /// The scenario is this one:
@@ -123,7 +123,7 @@ mod concurrency {
         // The lock guard simulate the start of the certificate insertion in the table.
         let lock_guard_certificate = store
             .fullnode_store
-            .get_certificate_lock_guard(parent.certificate.id)
+            .certificate_lock_guard(parent.certificate.id)
             .await;
 
         tokio::spawn(async move {
@@ -149,7 +149,7 @@ mod concurrency {
         // The lock guard simulate the start of the certificate insertion in the table.
         let lock_guard_subnet = store
             .fullnode_store
-            .get_subnet_lock_guard(cert.certificate.source_subnet_id)
+            .subnet_lock_guard(cert.certificate.source_subnet_id)
             .await;
 
         tokio::spawn(async move {
@@ -188,7 +188,7 @@ mod concurrency {
         // The lock guard simulate the start of the certificate insertion in the table.
         let lock_guard_subnet = store
             .fullnode_store
-            .get_subnet_lock_guard(cert.certificate.source_subnet_id)
+            .subnet_lock_guard(cert.certificate.source_subnet_id)
             .await;
 
         tokio::spawn(async move {

--- a/crates/topos-tce-storage/src/validator/mod.rs
+++ b/crates/topos-tce-storage/src/validator/mod.rs
@@ -293,7 +293,7 @@ impl ValidatorStore {
         // A lock guard is asked during the insertion of a pending certificate
         // to avoid race condition when a certificate is being inserted and added
         // to the pending pool at the same time
-        let _ = self
+        let _certificate_guard = self
             .fullnode_store
             .get_certificate_lock_guard(certificate.id)
             .await;
@@ -323,7 +323,7 @@ impl ValidatorStore {
         // A lock guard is asked during the insertion of a pending certificate
         // to avoid race condition when a certificate is being added to the
         // pending pool while its parent is currently being inserted as delivered
-        let _ = self
+        let _prev_certificate_guard = self
             .fullnode_store
             .get_certificate_lock_guard(certificate.prev_id)
             .await;

--- a/crates/topos-tce-storage/src/validator/mod.rs
+++ b/crates/topos-tce-storage/src/validator/mod.rs
@@ -286,10 +286,18 @@ impl ValidatorStore {
         Ok(ids)
     }
 
-    pub fn insert_pending_certificate(
+    pub async fn insert_pending_certificate(
         &self,
         certificate: &Certificate,
     ) -> Result<Option<PendingCertificateId>, StorageError> {
+        // A lock guard is asked during the insertion of a pending certificate
+        // to avoid race condition when a certificate is being inserted and added
+        // to the pending pool at the same time
+        let _ = self
+            .fullnode_store
+            .get_certificate_lock_guard(certificate.id)
+            .await;
+
         if self.get_certificate(&certificate.id)?.is_some() {
             debug!("Certificate {} is already delivered", certificate.id);
             return Err(StorageError::InternalStorage(
@@ -311,6 +319,14 @@ impl ValidatorStore {
                 InternalStorageError::CertificateAlreadyPending,
             ));
         }
+
+        // A lock guard is asked during the insertion of a pending certificate
+        // to avoid race condition when a certificate is being added to the
+        // pending pool while its parent is currently being inserted as delivered
+        let _ = self
+            .fullnode_store
+            .get_certificate_lock_guard(certificate.prev_id)
+            .await;
 
         let prev_delivered = certificate.prev_id == INITIAL_CERTIFICATE_ID
             || self.get_certificate(&certificate.prev_id)?.is_some();
@@ -624,7 +640,7 @@ impl WriteStore for ValidatorStore {
                 "Delivered certificate {} unlocks {} for broadcast",
                 certificate.certificate.id, next_certificate.id
             );
-            self.insert_pending_certificate(&next_certificate)?;
+            self.insert_pending_certificate(&next_certificate).await?;
             self.pending_tables
                 .precedence_pool
                 .delete(&certificate.certificate.id)?;

--- a/crates/topos-tce/src/app_context/api.rs
+++ b/crates/topos-tce/src/app_context/api.rs
@@ -23,6 +23,7 @@ impl AppContext {
                 _ = match self
                     .validator_store
                     .insert_pending_certificate(&certificate)
+                    .await
                 {
                     Ok(Some(pending_id)) => {
                         let certificate_id = certificate.id;

--- a/crates/topos-tce/src/app_context/network.rs
+++ b/crates/topos-tce/src/app_context/network.rs
@@ -42,7 +42,7 @@ impl AppContext {
                                 cert.id, from
                             );
 
-                            match self.validator_store.insert_pending_certificate(&cert) {
+                            match self.validator_store.insert_pending_certificate(&cert).await {
                                 Ok(Some(pending_id)) => {
                                     let certificate_id = cert.id;
                                     debug!(

--- a/crates/topos-tce/src/lib.rs
+++ b/crates/topos-tce/src/lib.rs
@@ -107,7 +107,7 @@ pub async fn run(
     let validator_store = ValidatorStore::new(path)
         .map_err(|error| format!("Unable to create validator store: {error}"))?;
 
-    let fullnode_store = validator_store.get_fullnode_store();
+    let fullnode_store = validator_store.fullnode_store();
 
     let storage_client = StorageClient::new(validator_store.clone());
 

--- a/crates/topos-test-sdk/src/crypto.rs
+++ b/crates/topos-test-sdk/src/crypto.rs
@@ -1,0 +1,9 @@
+use std::{str::FromStr, sync::Arc};
+
+use rstest::fixture;
+use topos_crypto::messages::MessageSigner;
+
+#[fixture(key = "122f3ae6ade1fd136b292cea4f6243c7811160352c8821528547a1fe7c459daf")]
+pub fn message_signer(key: &str) -> Arc<MessageSigner> {
+    Arc::new(MessageSigner::from_str(key).unwrap())
+}

--- a/crates/topos-test-sdk/src/lib.rs
+++ b/crates/topos-test-sdk/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod certificates;
 
+pub mod crypto;
 pub mod networking;
 pub mod p2p;
 pub mod sequencer;

--- a/crates/topos-test-sdk/src/tce/mod.rs
+++ b/crates/topos-test-sdk/src/tce/mod.rs
@@ -44,6 +44,7 @@ use self::p2p::{bootstrap_network, create_network_worker};
 use self::protocol::{create_reliable_broadcast_client, create_reliable_broadcast_params};
 use self::public_api::create_public_api;
 use self::synchronizer::create_synchronizer;
+use crate::crypto::message_signer;
 use crate::p2p::local_peer;
 use crate::storage::create_fullnode_store;
 use crate::storage::create_validator_store;
@@ -174,10 +175,6 @@ impl NodeConfig {
     }
 }
 
-fn default_message_signer() -> Arc<MessageSigner> {
-    Arc::new(MessageSigner::new(&[5u8; 32]).unwrap())
-}
-
 #[derive(Clone)]
 struct DummyService {}
 
@@ -207,9 +204,8 @@ pub fn create_dummy_router() -> Router {
     peers = &[],
     certificates = &[],
     validator_id = ValidatorId::default(),
-    validators = HashSet::default(),
-    message_signer = default_message_signer())
-]
+    validators = HashSet::default()
+)]
 pub async fn start_node(
     certificates: &[CertificateDelivered],
     config: NodeConfig,

--- a/crates/topos-test-sdk/src/tce/p2p.rs
+++ b/crates/topos-test-sdk/src/tce/p2p.rs
@@ -55,6 +55,7 @@ pub async fn create_network_worker(
         .listen_addresses(addr)
         .minimum_cluster_size(minimum_cluster_size)
         .grpc_context(grpc_context)
+        .allow_private_ip(true)
         .build()
         .in_current_span()
         .await


### PR DESCRIPTION
# Description

This PR is covering a corner case which involve the delivery of a prev certificate and a child certificate.

The scenario is this one:

- A `prev` certificate (`C1`) has been delivered (by the broadcast) and need to be persisted
  The persist method will hold a lock while performing multiple insert/delete to avoid
  insert race condition.
- At the same time, another node is sending a certificate (`C2`) which have `C1` as `prev_id`.
  `C2` is looking at the storage to find if the `prev_id` `C1` is delivered but find nothing as
  the `persist` method is still working at creating the `WriteBatch`. It led the node to put
  `C2` in the `precedence_pool` waiting for `C1` to be delivered while it is in fact already
  delivered.

To avoid that and as a first step, when trying to insert a certificate in the pending pool,
The node will try to acquire a lock guard on the certificate but also on the prev_id.

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
