### PR TITLE
chore: removing cache_size

### DIFF
--- a/crates/topos-p2p/src/behaviour/peer_info.rs
+++ b/crates/topos-p2p/src/behaviour/peer_info.rs
@@ -12,8 +12,7 @@ pub struct PeerInfoBehaviour {
 impl PeerInfoBehaviour {
     pub(crate) fn new(identify_protocol: &'static str, peer_key: &Keypair) -> PeerInfoBehaviour {
         let ident_config = IdentifyConfig::new(identify_protocol.to_string(), peer_key.public())
-            .with_push_listen_addr_updates(true)
-            .with_cache_size(0);
+            .with_push_listen_addr_updates(true);
 
         let identify = Identify::new(ident_config);
 


### PR DESCRIPTION
# Description

This PR is just removing a temporary config put in place during the creation of the `soft-fork` playbook.


## Additions and Changes

Removes the `with_cache_size` disabling the LRU cache of `identify` protocol.

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
