### PR TITLE
fix: update mio

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4557,9 +4557,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "wasi",


### PR DESCRIPTION
# Description

Fixing [RUSTSEC-2024-0019](https://rustsec.org/advisories/RUSTSEC-2024-0019.html). Windows specific, but nevertheless worth an upgrade:

> For users of Tokio, this vulnerability is serious and can result in a use-after-free in Tokio.
> The vulnerability is Windows-specific, and can only happen if you are using named pipes. Other IO resources are not affected.

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
