### PR TITLE
fix(config): fix the parse of edge_path ENV var

### DIFF
--- a/crates/topos-config/src/edge/command.rs
+++ b/crates/topos-config/src/edge/command.rs
@@ -64,7 +64,10 @@ impl CommandConfig {
     }
 
     pub async fn spawn(self) -> Result<ExitStatus, std::io::Error> {
-        info!("Spawning Polygon Edge with args: {:?}", self.binary_path);
+        info!(
+            "Spawning Polygon Edge binary located at: {:?}, args: {:?}",
+            self.binary_path, self.args
+        );
         let mut command = Command::new(self.binary_path);
         command.kill_on_drop(true);
         command.args(self.args);

--- a/crates/topos-config/src/genesis/mod.rs
+++ b/crates/topos-config/src/genesis/mod.rs
@@ -110,6 +110,6 @@ impl TryFrom<&NodeConfig> for Genesis {
     type Error = Error;
 
     fn try_from(config: &NodeConfig) -> Result<Self, Self::Error> {
-        Genesis::new(&config.edge_path)
+        Genesis::new(&config.genesis_path)
     }
 }

--- a/crates/topos-config/src/lib.rs
+++ b/crates/topos-config/src/lib.rs
@@ -46,7 +46,7 @@ pub trait Config: Serialize {
     /// It will load the configuration from the file and an optional existing struct (if any)
     /// and then extract the configuration from the context in order to build the Config.
     /// The Config is then returned or an error if the configuration is not valid.
-    fn load<S: Serialize>(home: &Path, config: Option<S>) -> Result<Self::Output, figment::Error> {
+    fn load<S: Serialize>(home: &Path, config: Option<&S>) -> Result<Self::Output, figment::Error> {
         let mut figment = Figment::new();
 
         figment = Self::load_from_file(figment, home);
@@ -61,7 +61,7 @@ pub trait Config: Serialize {
 
 pub(crate) fn load_config<T: Config, S: Serialize>(
     node_path: &Path,
-    config: Option<S>,
+    config: Option<&S>,
 ) -> T::Output {
     match T::load(node_path, config) {
         Ok(config) => config,

--- a/crates/topos-node/src/lib.rs
+++ b/crates/topos-node/src/lib.rs
@@ -12,7 +12,6 @@ use tokio::{
 };
 use tokio_util::sync::CancellationToken;
 use topos_config::{
-    edge::command::BINARY_NAME,
     genesis::Genesis,
     node::{NodeConfig, NodeRole},
 };
@@ -76,7 +75,7 @@ pub async fn start(
         info!(
             "Could not load genesis.json file on path {} \n Please make sure to have a valid \
              genesis.json file for your subnet in the {}/subnet/{} folder.",
-            config.edge_path.display(),
+            config.genesis_path.display(),
             config.home_path.display(),
             &config.base.subnet
         );
@@ -159,21 +158,22 @@ fn spawn_processes(
         info!("Using external edge node, skip running of local edge instance...")
     } else {
         let edge_config = config.edge.take().ok_or(Error::MissingEdgeConfig)?;
+        let edge_bin_config = config.edge_bin.take().ok_or(Error::MissingEdgeConfig)?;
 
         let data_dir = config.node_path.clone();
 
         info!(
             "Spawning edge process with genesis file: {}, data directory: {}, additional edge \
              arguments: {:?}",
-            config.edge_path.display(),
+            config.genesis_path.display(),
             data_dir.display(),
             edge_config.args
         );
 
         processes.push(process::spawn_edge_process(
-            config.home_path.join(BINARY_NAME),
+            edge_bin_config.binary_path(),
             data_dir,
-            config.edge_path.clone(),
+            config.genesis_path.clone(),
             edge_config.args,
         ));
     }

--- a/crates/topos/src/components/node/commands.rs
+++ b/crates/topos/src/components/node/commands.rs
@@ -30,7 +30,12 @@ pub(crate) struct NodeCommand {
     pub(crate) home: PathBuf,
 
     /// Installation directory path for Polygon Edge binary
-    #[arg(long, env = "TOPOS_POLYGON_EDGE_BIN_PATH", default_value = ".")]
+    #[arg(
+        global = true,
+        long,
+        env = "TOPOS_POLYGON_EDGE_BIN_PATH",
+        default_value = "."
+    )]
     pub(crate) edge_path: PathBuf,
 
     #[clap(subcommand)]

--- a/crates/topos/src/components/node/commands/init.rs
+++ b/crates/topos/src/components/node/commands/init.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use clap::Args;
 use serde::Serialize;
 use topos_config::node::NodeRole;
@@ -27,4 +29,8 @@ pub struct Init {
     /// rely on polygon-edge during runtime. Example: A sequencer which runs for an external EVM chain
     #[arg(long, env = "TOPOS_NO_EDGE_PROCESS", action)]
     pub no_edge_process: bool,
+
+    /// Installation directory path for Polygon Edge binary
+    #[clap(from_global)]
+    pub(crate) edge_path: PathBuf,
 }

--- a/crates/topos/src/components/node/commands/up.rs
+++ b/crates/topos/src/components/node/commands/up.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use clap::Args;
 use serde::Serialize;
 
@@ -26,4 +28,8 @@ pub struct Up {
     /// If not provided open telemetry will not be used
     #[arg(long, env = "TOPOS_OTLP_SERVICE_NAME")]
     pub otlp_service_name: Option<String>,
+
+    /// Installation directory path for Polygon Edge binary
+    #[clap(from_global)]
+    pub(crate) edge_path: PathBuf,
 }

--- a/crates/topos/src/components/node/mod.rs
+++ b/crates/topos/src/components/node/mod.rs
@@ -95,7 +95,7 @@ pub(crate) async fn handle_command(
                 }
             }
 
-            let node_config = NodeConfig::create(&home, &name, Some(cmd));
+            let node_config = NodeConfig::create(&home, &name, Some(&cmd));
 
             // Creating the TOML output
             let config_toml = match node_config.to_toml() {
@@ -135,7 +135,7 @@ pub(crate) async fn handle_command(
                 .as_ref()
                 .expect("No name or default was given for node");
 
-            let config = NodeConfig::try_from(&home, name, Some(command))?;
+            let config = NodeConfig::try_from(&home, name, Some(&command))?;
 
             topos_node::start(
                 verbose,

--- a/crates/topos/tests/node.rs
+++ b/crates/topos/tests/node.rs
@@ -99,4 +99,80 @@ mod serial_integration {
 
         Ok(())
     }
+
+    #[test_log::test(tokio::test)]
+    async fn command_node_up_custom_polygon() -> Result<(), Box<dyn std::error::Error>> {
+        let tmp_home_dir = tempdir()?;
+
+        // Create config file
+        let node_up_home_env = tmp_home_dir.path().to_str().unwrap();
+        let custom_path = tmp_home_dir.path().join("custom_path");
+        let node_edge_path_env = utils::setup_polygon_edge(custom_path.to_str().unwrap()).await;
+        let node_up_name_env = "TEST_NODE_UP";
+        let node_up_role_env = "full-node";
+        let node_up_subnet_env = "topos-up-env-subnet";
+
+        let mut cmd = Command::cargo_bin("topos")?;
+        cmd.arg("node")
+            .env("TOPOS_POLYGON_EDGE_BIN_PATH", &node_edge_path_env)
+            .env("TOPOS_HOME", node_up_home_env)
+            .env("TOPOS_NODE_NAME", node_up_name_env)
+            .env("TOPOS_NODE_ROLE", node_up_role_env)
+            .env("TOPOS_NODE_SUBNET", node_up_subnet_env)
+            .arg("init");
+
+        let output = cmd.assert().success();
+        let result: &str = std::str::from_utf8(&output.get_output().stdout)?;
+        assert!(result.contains("Created node config file"));
+
+        // Run node init with cli flags
+        let home = PathBuf::from(node_up_home_env);
+        // Verification: check that the config file was created
+        let config_path = home.join("node").join(node_up_name_env).join("config.toml");
+        assert!(config_path.exists());
+
+        // Generate polygon edge genesis file
+        let polygon_edge_bin = format!("{}/polygon-edge", node_edge_path_env);
+        generate_polygon_edge_genesis_file(
+            &polygon_edge_bin,
+            node_up_home_env,
+            node_up_name_env,
+            node_up_subnet_env,
+        )
+        .await?;
+        let polygon_edge_genesis_path = home
+            .join("subnet")
+            .join(node_up_subnet_env)
+            .join("genesis.json");
+        assert!(polygon_edge_genesis_path.exists());
+
+        let mut cmd = Command::cargo_bin("topos")?;
+        cmd.arg("node")
+            .env("TOPOS_POLYGON_EDGE_BIN_PATH", &node_edge_path_env)
+            .env("TOPOS_HOME", node_up_home_env)
+            .env("TOPOS_NODE_NAME", node_up_name_env)
+            .arg("up");
+
+        let mut cmd = tokio::process::Command::from(cmd).spawn().unwrap();
+        let pid = cmd.id().unwrap();
+        let _ = tokio::time::sleep(std::time::Duration::from_secs(10)).await;
+
+        let s = System::new_all();
+        if let Some(process) = s.process(Pid::from_u32(pid)) {
+            if process.kill_with(Signal::Term).is_none() {
+                eprintln!("This signal isn't supported on this platform");
+            }
+        }
+
+        if let Ok(code) = cmd.wait().await {
+            assert!(code.success());
+        } else {
+            panic!("Failed to shutdown gracefully");
+        }
+
+        // Cleanup
+        std::fs::remove_dir_all(node_up_home_env)?;
+
+        Ok(())
+    }
 }


### PR DESCRIPTION
# Description

This PR fixes the parsing of the `edge-path` when set by env var.
It also refactors a bit how the edge binary path is created and add non regression tests.


## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
