### PR TITLE
fix(p2p): rework ticks of bootstrap query interval

### DIFF
--- a/crates/topos-p2p/src/behaviour.rs
+++ b/crates/topos-p2p/src/behaviour.rs
@@ -9,7 +9,7 @@ pub(crate) mod peer_info;
 pub(crate) mod topos;
 
 /// Represents the health status of a behaviour inside the p2p layer
-#[derive(Default, PartialEq, Eq)]
+#[derive(Debug, Default, PartialEq, Eq)]
 pub(crate) enum HealthStatus {
     #[default]
     Initializing,

--- a/crates/topos-p2p/src/runtime/handle_event.rs
+++ b/crates/topos-p2p/src/runtime/handle_event.rs
@@ -197,6 +197,7 @@ impl EventHandler<SwarmEvent<ComposedEvent>> for Runtime {
             _ = self.event_sender.send(event).await;
         }
 
+        info!("Healthystatus: {:?}", self.health_status);
         Ok(())
     }
 }

--- a/crates/topos-tce-synchronizer/src/checkpoints_collector/tests/integration.rs
+++ b/crates/topos-tce-synchronizer/src/checkpoints_collector/tests/integration.rs
@@ -44,7 +44,6 @@ async fn network_test() {
         .bootstrap(&[cfg.clone(), boot_node.clone()], None)
         .await
         .unwrap();
-
     use topos_core::api::grpc::shared::v1::Uuid as APIUuid;
 
     let peer = boot_node.keypair.public().to_peer_id();


### PR DESCRIPTION
# Description

This PR reworks how we manage the ticks of the bootstrap queries.

After investigating an issue on `devnet` I saw that two queries were executed at the same second.
While the expected behavior is to have a delay of 60sec (by default).

### Why ?

```
09:33:29: DEBUG -> Started kademlia bootstrap query with query_id: QueryId(0)
                    ^ (1) This is the first query is created when the node starts
09:33:29: INFO  -> Dialing bootpeer 16Uiu2HAmTqPREKjx7dYpcEsjByzy8yZMgjipzAcStMFQBAvZZL73 on connection: 1
                    ^ We dial the other peer for this query
09:33:29: WARN  -> Unable to connect to bootpeer 16Uiu2HAmTqPREKjx7dYpcEsjByzy8yZMgjipzAcStMFQBAvZZL73
                    ^ The other bootnode is not available
09:33:29: WARN  -> Bootstrap query finished but unable to connect to bootnode during initialization, switching to unhealthy and fast bootstrap mode
                                    ^ The query finished but the bootnode was unreachable, switching to fast mode (5sec interval query)
09:33:29: INFO  -> Dialing bootpeer 16Uiu2HAmTqPREKjx7dYpcEsjByzy8yZMgjipzAcStMFQBAvZZL73 on connection: 2
                    ^ (2) New query created !
09:33:29: WARN  -> Unable to connect to bootpeer 16Uiu2HAmTqPREKjx7dYpcEsjByzy8yZMgjipzAcStMFQBAvZZL73
09:33:29: WARN  -> Bootstrap query finished but unable to connect to bootnode, retrying 2 more times
```

As we can see on the logs, the first query `(1)` fails, and we switch to fast mode for bootstrap as expected.
But the problem is that after changing the mode (basically, creating a new `interval` with shorter period), the next query `(2)` is directly executed.

This is due to the fact that the first `tick` of `interval` completes immediately and then the discovery `poll` function fire a new query.

### Fix

To fix that I updated the `change_interval` to await and ignore the first tick and switch the `MissedTickBehavior` to `delay` as we don't need any catchup on missing tick.

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
