### PR TITLE
fix(p2p): accept listener connection during bootstrap

### DIFF
--- a/crates/topos-p2p/src/network.rs
+++ b/crates/topos-p2p/src/network.rs
@@ -216,8 +216,8 @@ impl<'a> NetworkBuilder<'a> {
                 pending_record_requests: HashMap::new(),
                 shutdown,
                 health_state: crate::runtime::HealthState {
-                    bootpeer_connection_retries: 3,
-                    successfully_connected_to_bootpeer: if self.known_peers.is_empty() {
+                    bootnode_connection_retries: 3,
+                    successfully_connected_to_bootnode: if self.known_peers.is_empty() {
                         // Node seems to be a boot node
                         Some(ConnectionId::new_unchecked(0))
                     } else {

--- a/crates/topos-p2p/src/runtime/handle_event/discovery.rs
+++ b/crates/topos-p2p/src/runtime/handle_event/discovery.rs
@@ -45,7 +45,7 @@ impl EventHandler<Box<Event>> for Runtime {
             {
                 if self
                     .health_state
-                    .successfully_connected_to_bootpeer
+                    .successfully_connected_to_bootnode
                     .is_none()
                 {
                     warn!(
@@ -85,11 +85,11 @@ impl EventHandler<Box<Event>> for Runtime {
             } if num_remaining == 0
                 && self
                     .health_state
-                    .successfully_connected_to_bootpeer
+                    .successfully_connected_to_bootnode
                     .is_none()
                 && self.swarm.behaviour().discovery.health_status == HealthStatus::Unhealthy =>
             {
-                match self.health_state.bootpeer_connection_retries.checked_sub(1) {
+                match self.health_state.bootnode_connection_retries.checked_sub(1) {
                     None => {
                         error!(
                             "Bootstrap query finished but unable to connect to bootnode, stopping"
@@ -103,7 +103,7 @@ impl EventHandler<Box<Event>> for Runtime {
                              {} more times",
                             new
                         );
-                        self.health_state.bootpeer_connection_retries = new;
+                        self.health_state.bootnode_connection_retries = new;
                     }
                 }
             }
@@ -119,7 +119,7 @@ impl EventHandler<Box<Event>> for Runtime {
             } if num_remaining == 0
                 && self
                     .health_state
-                    .successfully_connected_to_bootpeer
+                    .successfully_connected_to_bootnode
                     .is_some()
                 && self.swarm.behaviour().discovery.health_status == HealthStatus::Unhealthy =>
             {

--- a/crates/topos-p2p/src/runtime/mod.rs
+++ b/crates/topos-p2p/src/runtime/mod.rs
@@ -62,11 +62,11 @@ pub(crate) struct HealthState {
     /// Indicates if the node is listening on any address
     pub(crate) is_listening: bool,
     /// List the bootnodes that the node has tried to connect to
-    pub(crate) dialed_bootpeer: HashSet<ConnectionId>,
+    pub(crate) dialed_bootnode: HashSet<ConnectionId>,
     /// Indicates if the node has successfully connected to a bootnode
-    pub(crate) successfully_connected_to_bootpeer: Option<ConnectionId>,
+    pub(crate) successfully_connected_to_bootnode: Option<ConnectionId>,
     /// Track the number of remaining retries to connect to any bootnode
-    pub(crate) bootpeer_connection_retries: usize,
+    pub(crate) bootnode_connection_retries: usize,
 }
 
 impl Runtime {


### PR DESCRIPTION
# Description

In order to safely initiate the bootnodes between each other, when receiving an incoming bootnode connection during bootstrap, dial back the bootnode.
## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
