### PR TITLE
feat(p2p/tce): add gossipsub message_id to tce logs

### DIFF
--- a/crates/topos-p2p/src/command.rs
+++ b/crates/topos-p2p/src/command.rs
@@ -1,6 +1,6 @@
 use std::fmt::Display;
 
-use libp2p::PeerId;
+use libp2p::{gossipsub::MessageId, PeerId};
 use tokio::sync::oneshot;
 
 use crate::{behaviour::grpc::connection::OutboundConnection, error::P2PError};
@@ -15,6 +15,7 @@ pub enum Command {
     Gossip {
         topic: &'static str,
         data: Vec<u8>,
+        sender: oneshot::Sender<Result<MessageId, P2PError>>,
     },
 
     /// Ask for the creation of a new proxy connection for a gRPC query.

--- a/crates/topos-p2p/src/error.rs
+++ b/crates/topos-p2p/src/error.rs
@@ -1,8 +1,11 @@
 use std::io;
 
 use libp2p::{
-    gossipsub::SubscriptionError, kad::NoKnownPeers, noise::Error as NoiseError,
-    request_response::OutboundFailure, TransportError,
+    gossipsub::{PublishError, SubscriptionError},
+    kad::NoKnownPeers,
+    noise::Error as NoiseError,
+    request_response::OutboundFailure,
+    TransportError,
 };
 use thiserror::Error;
 use tokio::sync::{mpsc, oneshot};
@@ -49,6 +52,12 @@ pub enum P2PError {
 
     #[error("Gossip topics subscription failed")]
     GossipTopicSubscriptionFailure,
+
+    #[error("Gossipsub publish failure: {0}")]
+    GossipsubPublishFailure(#[from] PublishError),
+
+    #[error("Invalid gossipsub topics: {0}")]
+    InvalidGossipTopic(&'static str),
 }
 
 #[derive(Error, Debug)]

--- a/crates/topos-p2p/src/event.rs
+++ b/crates/topos-p2p/src/event.rs
@@ -7,6 +7,7 @@ use crate::behaviour::{grpc, HealthStatus};
 pub enum GossipEvent {
     /// A message has been received from a peer on one of the subscribed topics
     Message {
+        propagated_by: PeerId,
         source: Option<PeerId>,
         topic: &'static str,
         message: Vec<u8>,
@@ -18,7 +19,7 @@ pub enum GossipEvent {
 pub enum ComposedEvent {
     Kademlia(Box<kad::Event>),
     PeerInfo(Box<identify::Event>),
-    Gossipsub(GossipEvent),
+    Gossipsub(Box<GossipEvent>),
     Grpc(grpc::Event),
     Void,
 }
@@ -49,9 +50,11 @@ impl From<void::Void> for ComposedEvent {
 
 /// Represents the events that the p2p layer can emit
 #[derive(Debug)]
+#[allow(clippy::large_enum_variant)]
 pub enum Event {
     /// An event emitted when a gossip message is received
     Gossip {
+        propagated_by: PeerId,
         from: PeerId,
         data: Vec<u8>,
         id: String,

--- a/crates/topos-p2p/src/event.rs
+++ b/crates/topos-p2p/src/event.rs
@@ -1,4 +1,4 @@
-use libp2p::{identify, kad, PeerId};
+use libp2p::{gossipsub::MessageId, identify, kad, PeerId};
 
 use crate::behaviour::{grpc, HealthStatus};
 
@@ -10,6 +10,7 @@ pub enum GossipEvent {
         source: Option<PeerId>,
         topic: &'static str,
         message: Vec<u8>,
+        id: MessageId,
     },
 }
 
@@ -50,7 +51,11 @@ impl From<void::Void> for ComposedEvent {
 #[derive(Debug)]
 pub enum Event {
     /// An event emitted when a gossip message is received
-    Gossip { from: PeerId, data: Vec<u8> },
+    Gossip {
+        from: PeerId,
+        data: Vec<u8>,
+        id: String,
+    },
     /// An event emitted when the p2p layer becomes healthy
     Healthy,
     /// An event emitted when the p2p layer becomes unhealthy

--- a/crates/topos-p2p/src/runtime/handle_command.rs
+++ b/crates/topos-p2p/src/runtime/handle_command.rs
@@ -5,7 +5,7 @@ use crate::{
 
 use rand::{thread_rng, Rng};
 use topos_metrics::P2P_MESSAGE_SENT_ON_GOSSIPSUB_TOTAL;
-use tracing::{debug, error, warn};
+use tracing::{error, trace, warn};
 
 impl Runtime {
     pub(crate) async fn handle_command(&mut self, command: Command) {
@@ -64,12 +64,17 @@ impl Runtime {
             Command::Gossip {
                 topic,
                 data: message,
+                sender,
             } => match self.swarm.behaviour_mut().gossipsub.publish(topic, message) {
                 Ok(message_id) => {
-                    debug!("Published message to {topic}");
+                    trace!("Published message to {topic}");
                     P2P_MESSAGE_SENT_ON_GOSSIPSUB_TOTAL.inc();
+                    _ = sender.send(Ok(message_id));
                 }
-                Err(err) => error!("Failed to publish message to {topic}: {err}"),
+                Err(err) => {
+                    error!("Failed to publish message to {topic}: {err}");
+                    _ = sender.send(Err(err));
+                }
             },
         }
     }

--- a/crates/topos-p2p/src/runtime/handle_event/gossipsub.rs
+++ b/crates/topos-p2p/src/runtime/handle_event/gossipsub.rs
@@ -9,27 +9,31 @@ use crate::{constants, event::GossipEvent, Event, Runtime, TOPOS_ECHO, TOPOS_GOS
 use super::{EventHandler, EventResult};
 
 #[async_trait::async_trait]
-impl EventHandler<GossipEvent> for Runtime {
-    async fn handle(&mut self, event: GossipEvent) -> EventResult {
+impl EventHandler<Box<GossipEvent>> for Runtime {
+    async fn handle(&mut self, event: Box<GossipEvent>) -> EventResult {
         if let GossipEvent::Message {
+            propagated_by,
             source: Some(source),
             message,
             topic,
             id,
-        } = event
+        } = *event
         {
             if self.event_sender.capacity() < *constants::CAPACITY_EVENT_STREAM_BUFFER {
                 P2P_EVENT_STREAM_CAPACITY_TOTAL.inc();
             }
 
-            debug!("Received message from {:?} on topic {:?}", source, topic);
+            debug!(
+                "Received message({id}) from source {:?} on topic {:?} propagated by {propagated_by}",
+                source, topic
+            );
 
             match topic {
                 TOPOS_GOSSIP => P2P_MESSAGE_RECEIVED_ON_GOSSIP_TOTAL.inc(),
                 TOPOS_ECHO => P2P_MESSAGE_RECEIVED_ON_ECHO_TOTAL.inc(),
                 TOPOS_READY => P2P_MESSAGE_RECEIVED_ON_READY_TOTAL.inc(),
                 _ => {
-                    error!("Received message on unknown topic {:?}", topic);
+                    error!("Received message({id}) on unknown topic {:?}", topic);
                     return Ok(());
                 }
             }
@@ -37,13 +41,14 @@ impl EventHandler<GossipEvent> for Runtime {
             if let Err(e) = self
                 .event_sender
                 .send(Event::Gossip {
+                    propagated_by,
                     from: source,
                     data: message,
                     id: id.to_string(),
                 })
                 .await
             {
-                error!("Failed to send gossip event to runtime: {:?}", e);
+                error!("Failed to send gossip event({id}) to runtime: {:?}", e);
             }
         }
 

--- a/crates/topos-p2p/src/runtime/handle_event/gossipsub.rs
+++ b/crates/topos-p2p/src/runtime/handle_event/gossipsub.rs
@@ -24,8 +24,11 @@ impl EventHandler<Box<GossipEvent>> for Runtime {
             }
 
             debug!(
-                "Received message({id}) from source {:?} on topic {:?} propagated by {propagated_by}",
-                source, topic
+                message_id = id.to_string(),
+                local_peer_id = self.local_peer_id.to_string(),
+                propagated_by = propagated_by.to_string(),
+                "Received message({id}) from source {source} on topic {:?} propagated by {propagated_by}",
+                topic
             );
 
             match topic {

--- a/crates/topos-p2p/src/runtime/handle_event/gossipsub.rs
+++ b/crates/topos-p2p/src/runtime/handle_event/gossipsub.rs
@@ -1,13 +1,10 @@
 use topos_metrics::{
-    P2P_EVENT_STREAM_CAPACITY_TOTAL, P2P_MESSAGE_DESERIALIZE_FAILURE_TOTAL,
-    P2P_MESSAGE_RECEIVED_ON_ECHO_TOTAL, P2P_MESSAGE_RECEIVED_ON_GOSSIP_TOTAL,
-    P2P_MESSAGE_RECEIVED_ON_READY_TOTAL,
+    P2P_EVENT_STREAM_CAPACITY_TOTAL, P2P_MESSAGE_RECEIVED_ON_ECHO_TOTAL,
+    P2P_MESSAGE_RECEIVED_ON_GOSSIP_TOTAL, P2P_MESSAGE_RECEIVED_ON_READY_TOTAL,
 };
 use tracing::{debug, error};
 
 use crate::{constants, event::GossipEvent, Event, Runtime, TOPOS_ECHO, TOPOS_GOSSIP, TOPOS_READY};
-use prost::Message;
-use topos_core::api::grpc::tce::v1::Batch;
 
 use super::{EventHandler, EventResult};
 
@@ -18,6 +15,7 @@ impl EventHandler<GossipEvent> for Runtime {
             source: Some(source),
             message,
             topic,
+            id,
         } = event
         {
             if self.event_sender.capacity() < *constants::CAPACITY_EVENT_STREAM_BUFFER {
@@ -25,49 +23,27 @@ impl EventHandler<GossipEvent> for Runtime {
             }
 
             debug!("Received message from {:?} on topic {:?}", source, topic);
-            match topic {
-                TOPOS_GOSSIP => {
-                    P2P_MESSAGE_RECEIVED_ON_GOSSIP_TOTAL.inc();
 
-                    if let Err(e) = self
-                        .event_sender
-                        .send(Event::Gossip {
-                            from: source,
-                            data: message,
-                        })
-                        .await
-                    {
-                        error!("Failed to send gossip event to runtime: {:?}", e);
-                    }
-                }
-                TOPOS_ECHO | TOPOS_READY => {
-                    if topic == TOPOS_ECHO {
-                        P2P_MESSAGE_RECEIVED_ON_ECHO_TOTAL.inc();
-                    } else {
-                        P2P_MESSAGE_RECEIVED_ON_READY_TOTAL.inc();
-                    }
-                    if let Ok(Batch { messages }) = Batch::decode(&message[..]) {
-                        for message in messages {
-                            if let Err(e) = self
-                                .event_sender
-                                .send(Event::Gossip {
-                                    from: source,
-                                    data: message,
-                                })
-                                .await
-                            {
-                                error!("Failed to send gossip {} event to runtime: {:?}", topic, e);
-                            }
-                        }
-                    } else {
-                        P2P_MESSAGE_DESERIALIZE_FAILURE_TOTAL
-                            .with_label_values(&[topic])
-                            .inc();
-                    }
-                }
+            match topic {
+                TOPOS_GOSSIP => P2P_MESSAGE_RECEIVED_ON_GOSSIP_TOTAL.inc(),
+                TOPOS_ECHO => P2P_MESSAGE_RECEIVED_ON_ECHO_TOTAL.inc(),
+                TOPOS_READY => P2P_MESSAGE_RECEIVED_ON_READY_TOTAL.inc(),
                 _ => {
                     error!("Received message on unknown topic {:?}", topic);
+                    return Ok(());
                 }
+            }
+
+            if let Err(e) = self
+                .event_sender
+                .send(Event::Gossip {
+                    from: source,
+                    data: message,
+                    id: id.to_string(),
+                })
+                .await
+            {
+                error!("Failed to send gossip event to runtime: {:?}", e);
             }
         }
 

--- a/crates/topos-tce/src/app_context/network.rs
+++ b/crates/topos-tce/src/app_context/network.rs
@@ -22,7 +22,13 @@ impl AppContext {
             &evt
         );
 
-        if let NetEvent::Gossip { data, from, id } = evt {
+        if let NetEvent::Gossip {
+            data,
+            propagated_by: received_from,
+            from,
+            id,
+        } = evt
+        {
             if let Ok(DoubleEchoRequest {
                 request: Some(double_echo_request),
             }) = DoubleEchoRequest::decode(&data[..])
@@ -39,10 +45,8 @@ impl AppContext {
                             }
                             info!(
                                 message_id = id,
-                                "Received certificate {} from GossipSub message({}) from {}",
+                                "Received certificate {} from GossipSub message({id}) from {from} | propagated by {received_from}",
                                 cert.id,
-                                id,
-                                from
                             );
 
                             match self.validator_store.insert_pending_certificate(&cert).await {
@@ -199,7 +203,7 @@ impl AppContext {
                             if let (Ok(certificate_id), Ok(validator_id)) =
                                 (certificate_id, validator_id)
                             {
-                                trace!(
+                                debug!(
                                     message_id = id,
                                     "Received Ready message({id}), certificate_id: \
                                      {certificate_id}, validator_id: {validator_id} from: {from}",

--- a/crates/topos-tce/src/app_context/protocol.rs
+++ b/crates/topos-tce/src/app_context/protocol.rs
@@ -1,6 +1,6 @@
 use topos_core::api::grpc::tce::v1::{double_echo_request, DoubleEchoRequest, Echo, Gossip, Ready};
 use topos_tce_broadcast::event::ProtocolEvents;
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 
 use crate::AppContext;
 
@@ -21,12 +21,16 @@ impl AppContext {
                 };
 
                 info!("Sending Gossip for certificate {}", cert_id);
-                if let Err(e) = self
+                match self
                     .network_client
                     .publish(topos_p2p::TOPOS_GOSSIP, request)
                     .await
                 {
-                    error!("Unable to send Gossip: {e}");
+                    Ok(id) => debug!(
+                        message_id = id,
+                        "Sent Gossip message({id}) for certificate {cert_id}"
+                    ),
+                    Err(e) => error!("Unable to send Gossip: {e}"),
                 }
             }
 
@@ -44,12 +48,16 @@ impl AppContext {
                     })),
                 };
 
-                if let Err(e) = self
+                match self
                     .network_client
                     .publish(topos_p2p::TOPOS_ECHO, request)
                     .await
                 {
-                    error!("Unable to send Echo: {e}");
+                    Ok(id) => debug!(
+                        message_id = id,
+                        "Sent Echo message({id}) for certificate {certificate_id}"
+                    ),
+                    Err(e) => error!("Unable to send Echo: {e}"),
                 }
             }
 
@@ -66,12 +74,16 @@ impl AppContext {
                     })),
                 };
 
-                if let Err(e) = self
+                match self
                     .network_client
                     .publish(topos_p2p::TOPOS_READY, request)
                     .await
                 {
-                    error!("Unable to send Ready: {e}");
+                    Ok(id) => debug!(
+                        message_id = id,
+                        "Sent Ready message({id}) for certificate {certificate_id}"
+                    ),
+                    Err(e) => error!("Unable to send Ready: {e}"),
                 }
             }
             ProtocolEvents::BroadcastFailed { certificate_id } => {

--- a/crates/topos-tce/src/tests/network.rs
+++ b/crates/topos-tce/src/tests/network.rs
@@ -39,6 +39,7 @@ async fn handle_gossip(
         .on_net_event(topos_p2p::Event::Gossip {
             from: PeerId::random(),
             data: msg.encode_to_vec(),
+            id: "0".to_string(),
         })
         .await;
 }
@@ -68,6 +69,7 @@ async fn handle_echo(
         .on_net_event(topos_p2p::Event::Gossip {
             from: PeerId::random(),
             data: msg.encode_to_vec(),
+            id: "0".to_string(),
         })
         .await;
 }
@@ -97,6 +99,7 @@ async fn handle_ready(
         .on_net_event(topos_p2p::Event::Gossip {
             from: PeerId::random(),
             data: msg.encode_to_vec(),
+            id: "0".to_string(),
         })
         .await;
 }
@@ -130,6 +133,7 @@ async fn handle_already_delivered(
         .on_net_event(topos_p2p::Event::Gossip {
             from: PeerId::random(),
             data: msg.encode_to_vec(),
+            id: "0".to_string(),
         })
         .await;
 }

--- a/crates/topos-tce/src/tests/network.rs
+++ b/crates/topos-tce/src/tests/network.rs
@@ -37,6 +37,7 @@ async fn handle_gossip(
     };
     context
         .on_net_event(topos_p2p::Event::Gossip {
+            propagated_by: PeerId::random(),
             from: PeerId::random(),
             data: msg.encode_to_vec(),
             id: "0".to_string(),
@@ -67,6 +68,7 @@ async fn handle_echo(
     };
     context
         .on_net_event(topos_p2p::Event::Gossip {
+            propagated_by: PeerId::random(),
             from: PeerId::random(),
             data: msg.encode_to_vec(),
             id: "0".to_string(),
@@ -97,6 +99,7 @@ async fn handle_ready(
     };
     context
         .on_net_event(topos_p2p::Event::Gossip {
+            propagated_by: PeerId::random(),
             from: PeerId::random(),
             data: msg.encode_to_vec(),
             id: "0".to_string(),
@@ -131,6 +134,7 @@ async fn handle_already_delivered(
 
     context
         .on_net_event(topos_p2p::Event::Gossip {
+            propagated_by: PeerId::random(),
             from: PeerId::random(),
             data: msg.encode_to_vec(),
             id: "0".to_string(),


### PR DESCRIPTION
# Description

To better understand the flow of a message on the network, we expose the `MessageId` generated during the GossipSub publication of `GOSSIP|ECHO|READY` message.
This `message_id` will then be placed in every related logs as metadata in order to filter on them in dashboard for exploration.

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
